### PR TITLE
feat(filmgrain): enable new midtone-baised film-grain

### DIFF
--- a/shaders/FilmGrain/FilmGrain_ps.hlsl
+++ b/shaders/FilmGrain/FilmGrain_ps.hlsl
@@ -5,7 +5,7 @@
 #define FILM_GRAIN_TEXTURE_SIZE 1024u
 
 // 0 Vanilla, 1 New Random (no flicker/repeating), 2 New random, no raised blacks
-#define FILM_GRAIN_TYPE 0
+#define FILM_GRAIN_TYPE 2
 
 cbuffer _13_15 : register(b0, space0)
 {


### PR DESCRIPTION
Fixes #11

Before:

![before-resized](https://github.com/EndlesslyFlowering/Starfield-Native-HDR/assets/9271155/57e63250-49c3-4414-b0e2-cdbe765c9265)

After:

![after-resized](https://github.com/EndlesslyFlowering/Starfield-Native-HDR/assets/9271155/a7bb17a3-4a11-4cbb-a9f8-2faa80e7cded)

Key Points:

Dark areas and light areas receive much less film grain. This improves clarify of dark areas without raising blacks. (Absolute black and white never receive grain)

![before-face](https://github.com/EndlesslyFlowering/Starfield-Native-HDR/assets/9271155/bf6210c2-e826-4e5d-a61e-2dd3f2579f48)
![after-face](https://github.com/EndlesslyFlowering/Starfield-Native-HDR/assets/9271155/f1cf3080-bc5a-496f-96b5-703b4349cc1d)

Midtone area (nearest 0.5 in SRGB) get stronger film grain boost, while trailing off the brighter it gets.

![before-whiteboard](https://github.com/EndlesslyFlowering/Starfield-Native-HDR/assets/9271155/866b0ded-3359-4173-ac39-e33b9c230780)

![after-whiteboard](https://github.com/EndlesslyFlowering/Starfield-Native-HDR/assets/9271155/f8b3812c-7150-4c65-abeb-41cd3d175969)

The strength can be adjusted through the standard Film Grain slider from the menu. This is 100, though 50 is probably more agreeable. 