### PR TITLE
fix float issues for CAS and add the missing 2 permutations

### DIFF
--- a/Plugin/src/Hooks.cpp
+++ b/Plugin/src/Hooks.cpp
@@ -424,6 +424,7 @@ namespace Hooks
 
 		case 0x1FE95:
 		case 0x201FE95:
+		case 0x401FE95:
 		case 0x601FE95:
 			{
 				Settings::ShaderConstants shaderConstants;

--- a/Plugin/src/Hooks.cpp
+++ b/Plugin/src/Hooks.cpp
@@ -422,7 +422,7 @@ namespace Hooks
 				break;
 			}
 
-		//case 0x1FE95:
+		case 0x1FE95:
 		case 0x201FE95:
 		case 0x601FE95:
 			{
@@ -467,7 +467,7 @@ namespace Hooks
 
 		settings->RegisterReshadeOverlay();
 
-		return _UnkFunc(a1, a_bgsSwapchainObject);		
+		return _UnkFunc(a1, a_bgsSwapchainObject);
     }
 
     void Hooks::Hook_UnkFunc2(uint64_t a1, uint64_t a2, uint64_t a3, uint64_t a4)

--- a/shaders/ContrastAdaptiveSharpening/ContrastAdaptiveSharpening_cs.hlsl
+++ b/shaders/ContrastAdaptiveSharpening/ContrastAdaptiveSharpening_cs.hlsl
@@ -6,17 +6,15 @@
 //#define USE_UPSCALING
 
 // shader permutations:
-// - CAS sharpening in FP32 [FF94] (USE_PACKED_MATH)
-// - CAS sharpening in FP16 with FFX_CAS_USE_PRECISE_MATH [100FF94]
-// - CAS upscaling in FP32 [200FF94] (USE_UPSCALING)
-// - CAS upscaling in FP16 with FFX_CAS_USE_PRECISE_MATH [300FF94] (USE_PACKED_MATH + USE_UPSCALING)
-
-// TODO: make full process in half not just after csp conversion? (needs matrices in half)
+// - CAS sharpening in FP32 [FF94/1FE95]
+// - CAS sharpening in FP16 with FFX_CAS_USE_PRECISE_MATH [100FF94/201FE95] (USE_PACKED_MATH)
+// - CAS upscaling in FP32 [200FF94/401FE95] (USE_UPSCALING)
+// - CAS upscaling in FP16 with FFX_CAS_USE_PRECISE_MATH [300FF94/601FE95] (USE_PACKED_MATH + USE_UPSCALING)
 
 // don't need it
 //cbuffer _16_18 : register(b0, space6)
 //{
-//	float4 _18_m0[8] : packoffset(c0); // _18_m0[1u].w = Gamma
+//	float4 _18_m0[9] : packoffset(c0); // _18_m0[1u].w = Gamma
 //};
 
 cbuffer CCASData : register(b0, space8)
@@ -45,17 +43,68 @@ struct CSInput
 //}
 
 #if SDR_LINEAR_INTERMEDIARY
-	#define GAMMA_TO_LINEAR(x) x
-	#define LINEAR_TO_GAMMA(x) x
+	#define GAMMA_TO_LINEAR_HALF(x) x
+	#define LINEAR_TO_GAMMA_HALF(x) x
+	#define GAMMA_TO_LINEAR_SINGLE(x) x
+	#define LINEAR_TO_GAMMA_SINGLE(x) x
 #elif SDR_USE_GAMMA_2_2 // NOTE: these gamma formulas should use their mirrored versions in the CLAMP_INPUT_OUTPUT_TYPE < 3 case
-	#define GAMMA_TO_LINEAR(x) pow(x, 2.2h)
-	#define LINEAR_TO_GAMMA(x) pow(x, half(1.f / 2.2f))
+	#define GAMMA_TO_LINEAR_HALF(x) pow(x, 2.2h)
+	#define LINEAR_TO_GAMMA_HALF(x) pow(x, half(1.f / 2.2f))
+	#define GAMMA_TO_LINEAR_SINGLE(x) pow(x, 2.2f)
+	#define LINEAR_TO_GAMMA_SINGLE(x) pow(x, 1.f / 2.2f)
 #else // doing sRGB in half is not accurate enough
-	#define GAMMA_TO_LINEAR(x) gamma_sRGB_to_linear(x)
-	#define LINEAR_TO_GAMMA(x) gamma_linear_to_sRGB(x)
+	#define GAMMA_TO_LINEAR_HALF(x) gamma_sRGB_to_linear(x)
+	#define LINEAR_TO_GAMMA_HALF(x) gamma_linear_to_sRGB(x)
+	#define GAMMA_TO_LINEAR_SINGLE(x) gamma_sRGB_to_linear(x)
+	#define LINEAR_TO_GAMMA_SINGLE(x) gamma_linear_to_sRGB(x)
 #endif
 
-half3 conditionalSaturate(half3 Color)
+
+#define CLAMPX(x) clamp(x, minX, maxX)
+#define CLAMPY(y) clamp(y, minY, maxY)
+
+
+float3 ConditionalSaturate(float3 Color)
+{
+#if CLAMP_INPUT_OUTPUT_TYPE >= 3
+	Color = saturate(Color);
+#endif
+	return Color;
+}
+
+float3 PrepareForProcessing(float3 Color)
+{
+	if (HdrDllPluginConstants.DisplayMode > 0)
+	{
+		Color /= PQMaxWhitePoint;
+		Color = BT709_To_WBT2020(Color);
+	}
+	else
+	{
+		Color = GAMMA_TO_LINEAR_SINGLE(Color);
+	}
+
+	return ConditionalSaturate(Color);
+}
+
+float3 PrepareForOutput(float3 Color)
+{
+	if (HdrDllPluginConstants.DisplayMode > 0)
+	{
+		Color = WBT2020_To_BT709(Color);
+		Color = Color * PQMaxWhitePoint;
+	}
+	else
+	{
+		Color = LINEAR_TO_GAMMA_SINGLE(Color);
+	}
+
+	return ConditionalSaturate(Color);
+}
+
+
+// could theoretically be used for SDR
+half3 ConditionalSaturate(half3 Color)
 {
 #if CLAMP_INPUT_OUTPUT_TYPE >= 3
 	Color = saturate(Color);
@@ -65,29 +114,16 @@ half3 conditionalSaturate(half3 Color)
 
 half3 PrepareForProcessing(half3 Color)
 {
-	if (HdrDllPluginConstants.DisplayMode > 0)
-	{
-		Color /= PQMaxWhitePoint;
-		Color = BT709_To_WBT2020(Color);
-	}
-	else
-	{
-		Color = GAMMA_TO_LINEAR(Color);
-	}
-	return conditionalSaturate(Color);
+	Color = GAMMA_TO_LINEAR_HALF(Color);
+
+	return ConditionalSaturate(Color);
 }
 
 half3 PrepareForOutput(half3 Color)
 {
-	if (HdrDllPluginConstants.DisplayMode > 0)
-	{
-		Color = WBT2020_To_BT709(Color);
-		return Color * PQMaxWhitePoint;
-	}
-	else
-	{
-		return LINEAR_TO_GAMMA(Color);
-	}
+	Color = LINEAR_TO_GAMMA_HALF(Color);
+
+	return ConditionalSaturate(Color);
 }
 
 
@@ -97,6 +133,8 @@ void CS(CSInput csInput)
 {
 #if defined(USE_PACKED_MATH) \
  && defined(USE_UPSCALING)
+
+// "FP16" CAS upscaling
 
 	uint4 _55 = CASData.rectLimits0;
 
@@ -109,621 +147,507 @@ void CS(CSInput csInput)
 	         | (csInput.SV_GroupID.y << 4);
 	_59 += _55.y;
 
-	CASConst0 _62 = CASData.upscalingConst0;
-	CASConst1 _69 = CASData.upscalingConst1;
+	static const bool testX0 = _58 <= _55.z;
+	static const bool testY0 = _59 <= _55.w;
 
-	float _85 = (float(_58) * _62.rcpScalingFactorX) + _62.otherScalingFactorX;
-	float _86 = (float(_59) * _62.rcpScalingFactorY) + _62.otherScalingFactorY;
-
-	half _91 = frac(_85);
-	half _93 = frac(_86);
-
-	uint _95 = uint(_85);
-	uint _96 = uint(_86);
-
-	uint _131 = _95 - 1;
-	uint _114 = _95;
-	uint _148 = _95 + 1;
-	uint _163 = _95 + 2;
-
-	uint _116 = _96 - 1;
-	uint _133 = _96;
-	uint _173 = _96 + 1;
-	uint _187 = _96 + 2;
-
-	half3 _118 = ColorIn.Load(int3(_114, _116, 0)).rgb;
-	half3 _134 = ColorIn.Load(int3(_131, _133, 0)).rgb;
-	half3 _138 = ColorIn.Load(int3(_114, _133, 0)).rgb;
-	half3 _149 = ColorIn.Load(int3(_148, _116, 0)).rgb;
-	half3 _153 = ColorIn.Load(int3(_148, _133, 0)).rgb;
-	half3 _164 = ColorIn.Load(int3(_163, _133, 0)).rgb;
-	half3 _174 = ColorIn.Load(int3(_131, _173, 0)).rgb;
-	half3 _178 = ColorIn.Load(int3(_114, _173, 0)).rgb;
-	half3 _188 = ColorIn.Load(int3(_114, _187, 0)).rgb;
-	half3 _192 = ColorIn.Load(int3(_148, _173, 0)).rgb;
-	half3 _196 = ColorIn.Load(int3(_163, _173, 0)).rgb;
-	half3 _200 = ColorIn.Load(int3(_148, _187, 0)).rgb;
-
-	float _205 = _85 + _69.rcpScalingFactorXTimes8;
-
-	half _208 = frac(_205);
-
-	uint _209 = uint(_205);
-
-	uint _228 = _209 - 1;
-	uint _214 = _209;
-	uint _250 = _209 + 1;
-	uint _272 = _209 + 2;
-
-	half3 _215 = ColorIn.Load(int3(_214, _116, 0)).rgb;
-	half3 _229 = ColorIn.Load(int3(_228, _133, 0)).rgb;
-	half3 _237 = ColorIn.Load(int3(_214, _133, 0)).rgb;
-	half3 _251 = ColorIn.Load(int3(_250, _116, 0)).rgb;
-	half3 _259 = ColorIn.Load(int3(_250, _133, 0)).rgb;
-	half3 _273 = ColorIn.Load(int3(_272, _133, 0)).rgb;
-	half3 _281 = ColorIn.Load(int3(_228, _173, 0)).rgb;
-	half3 _289 = ColorIn.Load(int3(_214, _173, 0)).rgb;
-	half3 _297 = ColorIn.Load(int3(_214, _187, 0)).rgb;
-	half3 _305 = ColorIn.Load(int3(_250, _173, 0)).rgb;
-	half3 _313 = ColorIn.Load(int3(_272, _173, 0)).rgb;
-	half3 _321 = ColorIn.Load(int3(_250, _187, 0)).rgb;
-
-	_118 = PrepareForProcessing(_118);
-	_134 = PrepareForProcessing(_134);
-	_138 = PrepareForProcessing(_138);
-	_149 = PrepareForProcessing(_149);
-	_153 = PrepareForProcessing(_153);
-	_164 = PrepareForProcessing(_164);
-	_174 = PrepareForProcessing(_174);
-	_178 = PrepareForProcessing(_178);
-	_188 = PrepareForProcessing(_188);
-	_192 = PrepareForProcessing(_192);
-	_196 = PrepareForProcessing(_196);
-	_200 = PrepareForProcessing(_200);
-	_215 = PrepareForProcessing(_215);
-	_229 = PrepareForProcessing(_229);
-	_237 = PrepareForProcessing(_237);
-	_251 = PrepareForProcessing(_251);
-	_259 = PrepareForProcessing(_259);
-	_273 = PrepareForProcessing(_273);
-	_281 = PrepareForProcessing(_281);
-	_289 = PrepareForProcessing(_289);
-	_297 = PrepareForProcessing(_297);
-	_305 = PrepareForProcessing(_305);
-	_313 = PrepareForProcessing(_313);
-	_321 = PrepareForProcessing(_321);
-
-	half _344 = _118.y;
-	half _345 = _215.y;
-	half _364 = _149.y;
-	half _365 = _251.y;
-	half _384 = _134.y;
-	half _385 = _229.y;
-	half _404 = _138.y;
-	half _405 = _237.y;
-	half _424 = _153.y;
-	half _425 = _259.y;
-	half _444 = _164.y;
-	half _445 = _273.y;
-	half _464 = _174.y;
-	half _465 = _281.y;
-	half _484 = _178.y;
-	half _485 = _289.y;
-	half _504 = _192.y;
-	half _505 = _305.y;
-	half _524 = _196.y;
-	half _525 = _313.y;
-	half _544 = _188.y;
-	half _545 = _297.y;
-	half _564 = _200.y;
-	half _565 = _321.y;
-
-	half _571 = min(_384, _404);
-	half _572 = min(_385, _405);
-	half _573 = min(_344, _571);
-	half _574 = min(_345, _572);
-	half _575 = min(_424, _484);
-	half _576 = min(_425, _485);
-	half _577 = min(_573, _575);
-	half _578 = min(_574, _576);
-	half _579 = max(_384, _404);
-	half _580 = max(_385, _405);
-	half _581 = max(_344, _579);
-	half _582 = max(_345, _580);
-	half _583 = max(_424, _484);
-	half _584 = max(_425, _485);
-	half _585 = max(_581, _583);
-	half _586 = max(_582, _584);
-	half _587 = min(_404, _424);
-	half _588 = min(_405, _425);
-	half _589 = min(_364, _587);
-	half _590 = min(_365, _588);
-	half _591 = min(_444, _504);
-	half _592 = min(_445, _505);
-	half _593 = min(_589, _591);
-	half _594 = min(_590, _592);
-	half _595 = max(_404, _424);
-	half _596 = max(_405, _425);
-	half _597 = max(_364, _595);
-	half _598 = max(_365, _596);
-	half _599 = max(_444, _504);
-	half _600 = max(_445, _505);
-	half _601 = max(_597, _599);
-	half _602 = max(_598, _600);
-	half _603 = min(_464, _484);
-	half _604 = min(_465, _485);
-	half _605 = min(_404, _603);
-	half _606 = min(_405, _604);
-	half _607 = min(_504, _544);
-	half _608 = min(_505, _545);
-	half _609 = min(_605, _607);
-	half _610 = min(_606, _608);
-	half _611 = max(_464, _484);
-	half _612 = max(_465, _485);
-	half _613 = max(_404, _611);
-	half _614 = max(_405, _612);
-	half _615 = max(_504, _544);
-	half _616 = max(_505, _545);
-	half _617 = max(_613, _615);
-	half _618 = max(_614, _616);
-	half _619 = min(_484, _504);
-	half _620 = min(_485, _505);
-	half _621 = min(_424, _619);
-	half _622 = min(_425, _620);
-	half _623 = min(_524, _564);
-	half _624 = min(_525, _565);
-	half _625 = min(_621, _623);
-	half _626 = min(_622, _624);
-	half _627 = max(_484, _504);
-	half _628 = max(_485, _505);
-	half _629 = max(_424, _627);
-	half _630 = max(_425, _628);
-	half _631 = max(_524, _564);
-	half _632 = max(_525, _565);
-	half _633 = max(_629, _631);
-	half _634 = max(_630, _632);
-
-	half _644 = 1.h - _585;
-	half _645 = 1.h - _586;
-	half _653 = 1.h - _601;
-	half _654 = 1.h - _602;
-	half _661 = 1.h - _617;
-	half _662 = 1.h - _618;
-	half _669 = 1.h - _633;
-	half _670 = 1.h - _634;
-
-	half _648 = 1.h / _585;
-	half _649 = 1.h / _586;
-	half _657 = 1.h / _601;
-	half _658 = 1.h / _602;
-	half _665 = 1.h / _617;
-	half _666 = 1.h / _618;
-	half _673 = 1.h / _633;
-	half _674 = 1.h / _634;
-
-	_648 *= min(_577, _644);
-	_649 *= min(_578, _645);
-	_657 *= min(_593, _653);
-	_658 *= min(_594, _654);
-	_665 *= min(_609, _661);
-	_666 *= min(_610, _662);
-	_673 *= min(_625, _669);
-	_674 *= min(_626, _670);
-
-	half _2515 = saturate(_648);
-	half _2526 = saturate(_649);
-	half _2547 = saturate(_657);
-	half _2558 = saturate(_658);
-	half _2579 = saturate(_665);
-	half _2590 = saturate(_666);
-	half _2611 = saturate(_673);
-	half _2622 = saturate(_674);
-
-	half hSharp = f16tof32(_69.sharpAsHalf & 0xFFFF);
-
-	half _699 = 1.h - _91;
-	half _700 = 1.h - _208;
-	half _701 = 1.h - _93;
-
-	half _717 = 0.03125h - _577;
-	half _718 = 0.03125h - _578;
-	half _725 = 0.03125h - _593;
-	half _726 = 0.03125h - _594;
-	half _733 = 0.03125h - _609;
-	half _734 = 0.03125h - _610;
-	half _741 = 0.03125h - _625;
-	half _742 = 0.03125h - _626;
-
-	_717 += _585;
-	_718 += _586;
-	_725 += _601;
-	_726 += _602;
-	_733 += _617;
-	_734 += _618;
-	_741 += _633;
-	_742 += _634;
-
-	_717 = 1.h / _717;
-	_718 = 1.h / _718;
-	_725 = 1.h / _725;
-	_726 = 1.h / _726;
-	_733 = 1.h / _733;
-	_734 = 1.h / _734;
-	_741 = 1.h / _741;
-	_742 = 1.h / _742;
-
-	_717 *= _701 * _699;
-	_718 *= _701 * _700;
-	_725 *= _701 *  _91;
-	_726 *= _701 * _208;
-	_733 *=  _93 * _699;
-	_734 *=  _93 * _700;
-	_741 *=  _93 *  _91;
-	_742 *=  _93 * _208;
-
-	half _743 = sqrt(_2515);
-	half _744 = sqrt(_2526);
-	half _745 = sqrt(_2547);
-	half _746 = sqrt(_2558);
-	half _747 = sqrt(_2579);
-	half _748 = sqrt(_2590);
-	half _753 = sqrt(_2611);
-	half _754 = sqrt(_2622);
-
-	_743 *= hSharp;
-	_744 *= hSharp;
-	_745 *= hSharp;
-	_746 *= hSharp;
-	_747 *= hSharp;
-	_748 *= hSharp;
-	_753 *= hSharp;
-	_754 *= hSharp;
-
-	_743 *= _717;
-	_744 *= _718;
-	_745 *= _725;
-	_746 *= _726;
-	_747 *= _733;
-	_748 *= _734;
-	_753 *= _741;
-	_754 *= _742;
-
-	half _750 = (_745 + _717) + _747;
-	half _752 = (_746 + _718) + _748;
-	half _756 = (_725 + _743) + _753;
-	half _758 = (_726 + _744) + _754;
-	half _760 = (_733 + _743) + _753;
-	half _762 = (_734 + _744) + _754;
-	half _765 = (_747 + _745) + _741;
-	half _766 = (_748 + _746) + _742;
-
-	half2 _783 = half2(_745 + _743 + _747 + _753,
-	                   _746 + _744 + _748 + _754);
-
-	_783 *= 2.h;
-
-	_783 += half2(_765 + _750 + _756 + _760,
-	              _766 + _752 + _758 + _762);
-
-	_783 = 1.h / _783;
-
-	half3 _803 = ((((((((_752 * _237) + (_744 * (_229 + _215))) + (_766 * _305)) + (_758 * _259)) + (_762 * _289)) + (_754 * (_321 + _313))) + (_748 * (_297 + _281))) + (_746 * (_273 + _251))) * _783.y;
-	half3 colorOut2 = conditionalSaturate(_803);
-
-	colorOut2 = PrepareForOutput(colorOut2);
-
-	if ((_58 <= _55.z) && (_59 <= _55.w))
+	if (testX0 && testY0)
 	{
-		half3 _961 = ((((((((_138 * _750) + ((_134 + _118) * _743)) + (_153 * _756)) + (_178 * _760)) + (_192 * _765)) + ((_200 + _196) * _753)) + ((_188 + _174) * _747)) + ((_164 + _149) * _745)) * _783.x;
-		half3 colorOut1 = conditionalSaturate(_961);
+		uint _1119 = _58 + 8;
+		uint _1153 = _59 + 8;
 
-		colorOut1 = PrepareForOutput(colorOut1);
+		CASConst0 _62 = CASData.upscalingConst0;
+		CASConst1 _69 = CASData.upscalingConst1;
 
-		ColorOut[uint2(_58, _59)] = float4(float3(colorOut1), 1.f);
-	}
+		uint4 _101 = CASData.rectLimits1;
 
-	uint _1119 = _58 + 8;
+		uint minX = _101.x;
+		uint minY = _101.y;
+		uint maxX = _101.z;
+		uint maxY = _101.w;
 
-	if ((_1119 <= _55.z) && (_59 <= _55.w))
-	{
-		ColorOut[uint2(_1119, _59)] = float4(float3(colorOut2), 1.f);
-	}
+		static const float sharp = _69.sharp;
 
-	uint _1153 = _59 + 8;
 
-	float _1156 = (float(_1153) * _62.rcpScalingFactorY) + _62.otherScalingFactorY;
+		float   _85 = (float(_58) * _62.rcpScalingFactorX) + _62.otherScalingFactorX;
+		float   _86 = (float(_59) * _62.rcpScalingFactorY) + _62.otherScalingFactorY;
+		float  _205 = _85 + _69.rcpScalingFactorXTimes8; // for some reason this optimisation only exists for the width
+		float _1156 = (float(_1153) * _62.rcpScalingFactorY) + _62.otherScalingFactorY;
 
-	half _1159 = frac(_1156);
+		float   _91 = frac(  _85);
+		float   _93 = frac(  _86);
+		float  _208 = frac( _205);
+		float _1159 = frac(_1156);
 
-	uint _1160 = uint(_1156);
+		uint   _95 = uint(  _85);
+		uint   _96 = uint(  _86);
+		uint  _209 = uint( _205);
+		uint _1160 = uint(_1156);
 
-	uint _1177 = _1160 - 1;
-	uint _1191 = _1160;
-	uint _1225 = _1160 + 1;
-	uint _1239 = _1160 + 2;
+		uint _131 = clamp(_95 - 1, minX, maxX);
+		uint _114 = clamp(_95,     minX, maxX);
+		uint _148 = clamp(_95 + 1, minX, maxX);
+		uint _163 = clamp(_95 + 2, minX, maxX);
 
-	half3 _1179 = ColorIn.Load(int3(_114, _1177, 0)).rgb;
-	half3 _1192 = ColorIn.Load(int3(_131, _1191, 0)).rgb;
-	half3 _1196 = ColorIn.Load(int3(_114, _1191, 0)).rgb;
-	half3 _1204 = ColorIn.Load(int3(_148, _1177, 0)).rgb;
-	half3 _1208 = ColorIn.Load(int3(_148, _1191, 0)).rgb;
-	half3 _1216 = ColorIn.Load(int3(_163, _1191, 0)).rgb;
-	half3 _1226 = ColorIn.Load(int3(_131, _1225, 0)).rgb;
-	half3 _1230 = ColorIn.Load(int3(_114, _1225, 0)).rgb;
-	half3 _1240 = ColorIn.Load(int3(_114, _1239, 0)).rgb;
-	half3 _1244 = ColorIn.Load(int3(_148, _1225, 0)).rgb;
-	half3 _1248 = ColorIn.Load(int3(_163, _1225, 0)).rgb;
-	half3 _1252 = ColorIn.Load(int3(_148, _1239, 0)).rgb;
-	half3 _1260 = ColorIn.Load(int3(_214, _1177, 0)).rgb;
-	half3 _1272 = ColorIn.Load(int3(_228, _1191, 0)).rgb;
-	half3 _1280 = ColorIn.Load(int3(_214, _1191, 0)).rgb;
-	half3 _1292 = ColorIn.Load(int3(_250, _1177, 0)).rgb;
-	half3 _1300 = ColorIn.Load(int3(_250, _1191, 0)).rgb;
-	half3 _1312 = ColorIn.Load(int3(_272, _1191, 0)).rgb;
-	half3 _1320 = ColorIn.Load(int3(_228, _1225, 0)).rgb;
-	half3 _1328 = ColorIn.Load(int3(_214, _1225, 0)).rgb;
-	half3 _1336 = ColorIn.Load(int3(_214, _1239, 0)).rgb;
-	half3 _1344 = ColorIn.Load(int3(_250, _1225, 0)).rgb;
-	half3 _1352 = ColorIn.Load(int3(_272, _1225, 0)).rgb;
-	half3 _1360 = ColorIn.Load(int3(_250, _1239, 0)).rgb;
+		uint _116 = clamp(_96 - 1, minY, maxY);
+		uint _133 = clamp(_96,     minY, maxY);
+		uint _173 = clamp(_96 + 1, minY, maxY);
+		uint _187 = clamp(_96 + 2, minY, maxY);
 
-	_1179 = PrepareForProcessing(_1179);
-	_1192 = PrepareForProcessing(_1192);
-	_1196 = PrepareForProcessing(_1196);
-	_1204 = PrepareForProcessing(_1204);
-	_1208 = PrepareForProcessing(_1208);
-	_1216 = PrepareForProcessing(_1216);
-	_1226 = PrepareForProcessing(_1226);
-	_1230 = PrepareForProcessing(_1230);
-	_1240 = PrepareForProcessing(_1240);
-	_1244 = PrepareForProcessing(_1244);
-	_1248 = PrepareForProcessing(_1248);
-	_1252 = PrepareForProcessing(_1252);
-	_1260 = PrepareForProcessing(_1260);
-	_1272 = PrepareForProcessing(_1272);
-	_1280 = PrepareForProcessing(_1280);
-	_1292 = PrepareForProcessing(_1292);
-	_1300 = PrepareForProcessing(_1300);
-	_1312 = PrepareForProcessing(_1312);
-	_1320 = PrepareForProcessing(_1320);
-	_1328 = PrepareForProcessing(_1328);
-	_1336 = PrepareForProcessing(_1336);
-	_1344 = PrepareForProcessing(_1344);
-	_1352 = PrepareForProcessing(_1352);
-	_1360 = PrepareForProcessing(_1360);
+		uint _228 = clamp(_209 - 1, minX, maxX);
+		uint _214 = clamp(_209,     minX, maxX);
+		uint _250 = clamp(_209 + 1, minX, maxX);
+		uint _272 = clamp(_209 + 2, minX, maxX);
 
-	half _1385 = _1179.y;
-	half _1386 = _1260.y;
-	half _1405 = _1204.y;
-	half _1406 = _1292.y;
-	half _1425 = _1192.y;
-	half _1426 = _1272.y;
-	half _1445 = _1196.y;
-	half _1446 = _1280.y;
-	half _1465 = _1208.y;
-	half _1466 = _1300.y;
-	half _1485 = _1216.y;
-	half _1486 = _1312.y;
-	half _1505 = _1226.y;
-	half _1506 = _1320.y;
-	half _1525 = _1230.y;
-	half _1526 = _1328.y;
-	half _1545 = _1244.y;
-	half _1546 = _1344.y;
-	half _1565 = _1248.y;
-	half _1566 = _1352.y;
-	half _1585 = _1240.y;
-	half _1586 = _1336.y;
-	half _1605 = _1252.y;
-	half _1606 = _1360.y;
+		uint _1177 = clamp(_1160 - 1, minY, maxY);
+		uint _1191 = clamp(_1160,     minY, maxY);
+		uint _1225 = clamp(_1160 + 1, minY, maxY);
+		uint _1239 = clamp(_1160 + 2, minY, maxY);
 
-	half _1612 = min(_1425, _1445);
-	half _1613 = min(_1426, _1446);
-	half _1614 = min(_1385, _1612);
-	half _1615 = min(_1386, _1613);
-	half _1616 = min(_1465, _1525);
-	half _1617 = min(_1466, _1526);
-	half _1618 = min(_1614, _1616);
-	half _1619 = min(_1615, _1617);
-	half _1620 = max(_1425, _1445);
-	half _1621 = max(_1426, _1446);
-	half _1622 = max(_1385, _1620);
-	half _1623 = max(_1386, _1621);
-	half _1624 = max(_1465, _1525);
-	half _1625 = max(_1466, _1526);
-	half _1626 = max(_1622, _1624);
-	half _1627 = max(_1623, _1625);
-	half _1628 = min(_1445, _1465);
-	half _1629 = min(_1446, _1466);
-	half _1630 = min(_1405, _1628);
-	half _1631 = min(_1406, _1629);
-	half _1632 = min(_1485, _1545);
-	half _1633 = min(_1486, _1546);
-	half _1634 = min(_1630, _1632);
-	half _1635 = min(_1631, _1633);
-	half _1636 = max(_1445, _1465);
-	half _1637 = max(_1446, _1466);
-	half _1638 = max(_1405, _1636);
-	half _1639 = max(_1406, _1637);
-	half _1640 = max(_1485, _1545);
-	half _1641 = max(_1486, _1546);
-	half _1642 = max(_1638, _1640);
-	half _1643 = max(_1639, _1641);
-	half _1644 = min(_1505, _1525);
-	half _1645 = min(_1506, _1526);
-	half _1646 = min(_1445, _1644);
-	half _1647 = min(_1446, _1645);
-	half _1648 = min(_1545, _1585);
-	half _1649 = min(_1546, _1586);
-	half _1650 = min(_1646, _1648);
-	half _1651 = min(_1647, _1649);
-	half _1652 = max(_1505, _1525);
-	half _1653 = max(_1506, _1526);
-	half _1654 = max(_1445, _1652);
-	half _1655 = max(_1446, _1653);
-	half _1656 = max(_1545, _1585);
-	half _1657 = max(_1546, _1586);
-	half _1658 = max(_1654, _1656);
-	half _1659 = max(_1655, _1657);
-	half _1660 = min(_1525, _1545);
-	half _1661 = min(_1526, _1546);
-	half _1662 = min(_1465, _1660);
-	half _1663 = min(_1466, _1661);
-	half _1664 = min(_1565, _1605);
-	half _1665 = min(_1566, _1606);
-	half _1666 = min(_1662, _1664);
-	half _1667 = min(_1663, _1665);
-	half _1668 = max(_1525, _1545);
-	half _1669 = max(_1526, _1546);
-	half _1670 = max(_1465, _1668);
-	half _1671 = max(_1466, _1669);
-	half _1672 = max(_1565, _1605);
-	half _1673 = max(_1566, _1606);
-	half _1674 = max(_1670, _1672);
-	half _1675 = max(_1671, _1673);
 
-	half _1684 = 1.h - _1626;
-	half _1685 = 1.h - _1627;
-	half _1692 = 1.h - _1642;
-	half _1693 = 1.h - _1643;
-	half _1700 = 1.h - _1658;
-	half _1701 = 1.h - _1659;
-	half _1708 = 1.h - _1674;
-	half _1709 = 1.h - _1675;
+		//  a b c d
+		//  e f g h
+		//  i j k l
+		//  m n o p
 
-	half _1688 = 1.h / _1626;
-	half _1689 = 1.h / _1627;
-	half _1696 = 1.h / _1642;
-	half _1697 = 1.h / _1643;
-	half _1704 = 1.h / _1658;
-	half _1705 = 1.h / _1659;
-	half _1712 = 1.h / _1674;
-	half _1713 = 1.h / _1675;
+		float3 b0 = ColorIn.Load(int3(_114, _116, 0)).rgb;
+		float3 e0 = ColorIn.Load(int3(_131, _133, 0)).rgb;
+		float3 f0 = ColorIn.Load(int3(_114, _133, 0)).rgb;
+		float3 c0 = ColorIn.Load(int3(_148, _116, 0)).rgb;
+		float3 g0 = ColorIn.Load(int3(_148, _133, 0)).rgb;
+		float3 h0 = ColorIn.Load(int3(_163, _133, 0)).rgb;
+		float3 i0 = ColorIn.Load(int3(_131, _173, 0)).rgb;
+		float3 j0 = ColorIn.Load(int3(_114, _173, 0)).rgb;
+		float3 n0 = ColorIn.Load(int3(_114, _187, 0)).rgb;
+		float3 k0 = ColorIn.Load(int3(_148, _173, 0)).rgb;
+		float3 l0 = ColorIn.Load(int3(_163, _173, 0)).rgb;
+		float3 o0 = ColorIn.Load(int3(_148, _187, 0)).rgb;
 
-	_1688 *= min(_1618, _1684);
-	_1689 *= min(_1619, _1685);
-	_1696 *= min(_1634, _1692);
-	_1697 *= min(_1635, _1693);
-	_1704 *= min(_1650, _1700);
-	_1705 *= min(_1651, _1701);
-	_1712 *= min(_1666, _1708);
-	_1713 *= min(_1667, _1709);
+		b0 = PrepareForProcessing(b0);
+		c0 = PrepareForProcessing(c0);
+		e0 = PrepareForProcessing(e0);
+		f0 = PrepareForProcessing(f0);
+		g0 = PrepareForProcessing(g0);
+		h0 = PrepareForProcessing(h0);
+		i0 = PrepareForProcessing(i0);
+		j0 = PrepareForProcessing(j0);
+		k0 = PrepareForProcessing(k0);
+		l0 = PrepareForProcessing(l0);
+		n0 = PrepareForProcessing(n0);
+		o0 = PrepareForProcessing(o0);
 
-	half _3064 = saturate(_1688);
-	half _3075 = saturate(_1689);
-	half _3096 = saturate(_1696);
-	half _3107 = saturate(_1697);
-	half _3128 = saturate(_1704);
-	half _3139 = saturate(_1705);
-	half _3160 = saturate(_1712);
-	half _3171 = saturate(_1713);
+  	float3 _577 = min(min(b0, min(e0, f0)), min(g0, j0));
+  	float3 _593 = min(min(c0, min(f0, g0)), min(h0, k0));
+  	float3 _609 = min(min(f0, min(i0, j0)), min(k0, n0));
+  	float3 _625 = min(min(g0, min(j0, k0)), min(l0, o0));
 
-	half _1732 = 1.h - _1159;
+  	float3 _585 = max(max(b0, max(e0, f0)), max(g0, j0));
+  	float3 _601 = max(max(c0, max(f0, g0)), max(h0, k0));
+  	float3 _617 = max(max(f0, max(i0, j0)), max(k0, n0));
+  	float3 _633 = max(max(g0, max(j0, k0)), max(l0, o0));
 
-	half _1747 = 0.03125h - _1618;
-	half _1748 = 0.03125h - _1619;
-	half _1755 = 0.03125h - _1634;
-	half _1756 = 0.03125h - _1635;
-	half _1763 = 0.03125h - _1650;
-	half _1764 = 0.03125h - _1651;
-	half _1771 = 0.03125h - _1666;
-	half _1772 = 0.03125h - _1667;
+		float3 _644 = 1.f - _585;
+		float3 _653 = 1.f - _601;
+		float3 _661 = 1.f - _617;
+		float3 _669 = 1.f - _633;
 
-	_1747 += _1626;
-	_1748 += _1627;
-	_1755 += _1642;
-	_1756 += _1643;
-	_1763 += _1658;
-	_1764 += _1659;
-	_1771 += _1674;
-	_1772 += _1675;
+		float3 _648 = 1.f / _585;
+		float3 _657 = 1.f / _601;
+		float3 _665 = 1.f / _617;
+		float3 _673 = 1.f / _633;
 
-	_1747 = 1.h / _1747;
-	_1748 = 1.h / _1748;
-	_1755 = 1.h / _1755;
-	_1756 = 1.h / _1756;
-	_1763 = 1.h / _1763;
-	_1764 = 1.h / _1764;
-	_1771 = 1.h / _1771;
-	_1772 = 1.h / _1772;
+		_648 *= min(_577, _644);
+		_657 *= min(_593, _653);
+		_665 *= min(_609, _661);
+		_673 *= min(_625, _669);
 
-	_1747 *= _1732 * _699;
-	_1748 *= _1732 * _700;
-	_1755 *= _1732 *  _91;
-	_1756 *= _1732 * _208;
-	_1763 *= _1159 * _699;
-	_1764 *= _1159 * _700;
-	_1771 *= _1159 *  _91;
-	_1772 *= _1159 * _208;
+		float3 _2515 = saturate(_648);
+		float3 _2547 = saturate(_657);
+		float3 _2579 = saturate(_665);
+		float3 _2611 = saturate(_673);
 
-	half _1773 = sqrt(_3064);
-	half _1774 = sqrt(_3075);
-	half _1775 = sqrt(_3096);
-	half _1776 = sqrt(_3107);
-	half _1777 = sqrt(_3128);
-	half _1778 = sqrt(_3139);
-	half _1783 = sqrt(_3160);
-	half _1784 = sqrt(_3171);
+		float3  _699 = 1.f   - _91;
+		float3  _701 = 1.f   - _93;
+		float3  _700 = 1.f  - _208;
+		float3 _1732 = 1.f - _1159;
 
-	_1773 *= hSharp;
-	_1774 *= hSharp;
-	_1775 *= hSharp;
-	_1776 *= hSharp;
-	_1777 *= hSharp;
-	_1778 *= hSharp;
-	_1783 *= hSharp;
-	_1784 *= hSharp;
+		float3 _717 = 0.03125f - _577;
+		float3 _725 = 0.03125f - _593;
+		float3 _733 = 0.03125f - _609;
+		float3 _741 = 0.03125f - _625;
 
-	_1773 *= _1747;
-	_1774 *= _1748;
-	_1775 *= _1755;
-	_1776 *= _1756;
-	_1777 *= _1763;
-	_1778 *= _1764;
-	_1783 *= _1771;
-	_1784 *= _1772;
+		_717 += _585;
+		_725 += _601;
+		_733 += _617;
+		_741 += _633;
 
-	half _1780 = (_1775 + _1747) + _1777;
-	half _1782 = (_1776 + _1748) + _1778;
-	half _1786 = (_1755 + _1773) + _1783;
-	half _1788 = (_1756 + _1774) + _1784;
-	half _1790 = (_1763 + _1773) + _1783;
-	half _1792 = (_1764 + _1774) + _1784;
-	half _1795 = (_1777 + _1775) + _1771;
-	half _1796 = (_1778 + _1776) + _1772;
+		_717 = 1.f / _717;
+		_725 = 1.f / _725;
+		_733 = 1.f / _733;
+		_741 = 1.f / _741;
 
-	half2 _1812 = half2(_1775 + _1773 + _1777 + _1783,
-	                    _1776 + _1774 + _1778 + _1784);
+		_717 *= _701 * _699;
+		_725 *= _701 *  _91;
+		_733 *=  _93 * _699;
+		_741 *=  _93 *  _91;
 
-	_1812 *= 2.h;
+		float3 _743 = sqrt(_2515);
+		float3 _745 = sqrt(_2547);
+		float3 _747 = sqrt(_2579);
+		float3 _753 = sqrt(_2611);
 
-	_1812 += half2(_1795 + _1780 + _1786 + _1790,
-	               _1796 + _1782 + _1788 + _1792);
+		_743 *= sharp;
+		_745 *= sharp;
+		_747 *= sharp;
+		_753 *= sharp;
 
-	_1812 = 1.h / _1812;
+		_743 *= _717;
+		_745 *= _725;
+		_747 *= _733;
+		_753 *= _741;
 
-	half3 _1832 = ((((((((_1782 * _1280) + (_1774 * (_1272 + _1260))) + (_1796 * _1344)) + (_1788 * _1300)) + (_1792 * _1328)) + (_1784 * (_1360 + _1352))) + (_1778 * (_1336 + _1320))) + (_1776 * (_1312 + _1292))) * _1812.y;
-	half3 colorOut4 = conditionalSaturate(_1832);
+		float3 _750 = (_745 + _717) + _747;
+		float3 _756 = (_725 + _743) + _753;
+		float3 _760 = (_733 + _743) + _753;
+		float3 _765 = (_747 + _745) + _741;
 
-	colorOut4 = PrepareForOutput(colorOut4);
+		float3 _784 = 1.f / (((_745 + _743 + _747 + _753) * 2.f) + _765 + _750 + _756 + _760);
 
-	if ((_58 <= _55.z) && (_1153 <= _55.w))
-	{
-		half3 _1987 = ((((((((_1196 * _1780) + ((_1192 + _1179) * _1773)) + (_1208 * _1786)) + (_1230 * _1790)) + (_1244 * _1795)) + ((_1252 + _1248) * _1783)) + ((_1240 + _1226) * _1777)) + ((_1216 + _1204) * _1775)) * _1812.x;
-		half3 colorOut3 = conditionalSaturate(_1987);
+		float3 colorOut0 = ((((((((f0 *  _750) + ((e0 + b0) *  _743)) + (g0 *  _756)) + (j0 *  _760)) + (k0 *  _765)) + ((o0 + l0) *  _753)) + ((n0 + i0) *  _747)) + ((h0 + c0) *  _745)) *  _784;
 
-		colorOut3 = PrepareForOutput(colorOut3);
+		colorOut0 = PrepareForOutput(colorOut0);
 
-		ColorOut[uint2(_58, _1153)] = float4(float3(colorOut3), 1.f);
-	}
+		ColorOut[uint2(_58, _59)] = float4(colorOut0, 1.f);
 
-	if ((_1119 <= _55.z) && (_1153 <= _55.w))
-	{
-		ColorOut[uint2(_1119, _1153)] = float4(float3(colorOut4), 1.f);
+		static const bool testX1 = _1119 <= _55.z;
+		static const bool testY1 = _1153 <= _55.w;
+
+		if (testX1)
+		{
+			float3 b1 = ColorIn.Load(int3(_214, _116, 0)).rgb;
+			float3 e1 = ColorIn.Load(int3(_228, _133, 0)).rgb;
+			float3 f1 = ColorIn.Load(int3(_214, _133, 0)).rgb;
+			float3 c1 = ColorIn.Load(int3(_250, _116, 0)).rgb;
+			float3 g1 = ColorIn.Load(int3(_250, _133, 0)).rgb;
+			float3 h1 = ColorIn.Load(int3(_272, _133, 0)).rgb;
+			float3 i1 = ColorIn.Load(int3(_228, _173, 0)).rgb;
+			float3 j1 = ColorIn.Load(int3(_214, _173, 0)).rgb;
+			float3 n1 = ColorIn.Load(int3(_214, _187, 0)).rgb;
+			float3 k1 = ColorIn.Load(int3(_250, _173, 0)).rgb;
+			float3 l1 = ColorIn.Load(int3(_272, _173, 0)).rgb;
+			float3 o1 = ColorIn.Load(int3(_250, _187, 0)).rgb;
+
+			b1 = PrepareForProcessing(b1);
+			c1 = PrepareForProcessing(c1);
+			e1 = PrepareForProcessing(e1);
+			f1 = PrepareForProcessing(f1);
+			g1 = PrepareForProcessing(g1);
+			h1 = PrepareForProcessing(h1);
+			i1 = PrepareForProcessing(i1);
+			j1 = PrepareForProcessing(j1);
+			k1 = PrepareForProcessing(k1);
+			l1 = PrepareForProcessing(l1);
+			n1 = PrepareForProcessing(n1);
+			o1 = PrepareForProcessing(o1);
+
+		  float3 _578 = min(min(b1, min(e1, f1)), min(g1, j1));
+		  float3 _594 = min(min(c1, min(f1, g1)), min(h1, k1));
+		  float3 _610 = min(min(f1, min(i1, j1)), min(k1, n1));
+		  float3 _626 = min(min(g1, min(j1, k1)), min(l1, o1));
+
+		  float3 _586 = max(max(b1, max(e1, f1)), max(g1, j1));
+		  float3 _602 = max(max(c1, max(f1, g1)), max(h1, k1));
+		  float3 _618 = max(max(f1, max(i1, j1)), max(k1, n1));
+		  float3 _634 = max(max(g1, max(j1, k1)), max(l1, o1));
+
+			float3 _645 = 1.f - _586;
+			float3 _654 = 1.f - _602;
+			float3 _662 = 1.f - _618;
+			float3 _670 = 1.f - _634;
+
+			float3 _649 = 1.f / _586;
+			float3 _658 = 1.f / _602;
+			float3 _666 = 1.f / _618;
+			float3 _674 = 1.f / _634;
+
+			_649 *= min(_578, _645);
+			_658 *= min(_594, _654);
+			_666 *= min(_610, _662);
+			_674 *= min(_626, _670);
+
+			float3 _2526 = saturate(_649);
+			float3 _2558 = saturate(_658);
+			float3 _2590 = saturate(_666);
+			float3 _2622 = saturate(_674);
+
+			float3 _718 = 0.03125f - _578;
+			float3 _726 = 0.03125f - _594;
+			float3 _734 = 0.03125f - _610;
+			float3 _742 = 0.03125f - _626;
+
+			_718 += _586;
+			_726 += _602;
+			_734 += _618;
+			_742 += _634;
+
+			_718 = 1.f / _718;
+			_726 = 1.f / _726;
+			_734 = 1.f / _734;
+			_742 = 1.f / _742;
+
+			_718 *= _701 * _700;
+			_726 *= _701 * _208;
+			_734 *=  _93 * _700;
+			_742 *=  _93 * _208;
+
+			float3 _744 = sqrt(_2526);
+			float3 _746 = sqrt(_2558);
+			float3 _748 = sqrt(_2590);
+			float3 _754 = sqrt(_2622);
+
+			_744 *= sharp;
+			_746 *= sharp;
+			_748 *= sharp;
+			_754 *= sharp;
+
+			_744 *= _718;
+			_746 *= _726;
+			_748 *= _734;
+			_754 *= _742;
+
+			float3 _752 = (_746 + _718) + _748;
+			float3 _758 = (_726 + _744) + _754;
+			float3 _762 = (_734 + _744) + _754;
+			float3 _766 = (_748 + _746) + _742;
+
+			float3 _785 = 1.f /(((_746 + _744 + _748 + _754) * 2.f) + _766 + _752 + _758 + _762);
+
+			float3 colorOut1 = ((((((((f1 *  _752) + ((e1 + b1) *  _744)) + (k1 *  _766)) + (g1 *  _758)) + (j1 *  _762)) + ((o1 + l1) *  _754)) + ((n1 + i1) *  _748)) + ((h1 + c1) *  _746)) *  _785;
+
+			colorOut1 = PrepareForOutput(colorOut1);
+
+			ColorOut[uint2(_1119, _59)] = float4(colorOut1, 1.f);
+
+			if (testY1)
+			{
+				float3 b3 = ColorIn.Load(int3(_214, _1177, 0)).rgb;
+				float3 e3 = ColorIn.Load(int3(_228, _1191, 0)).rgb;
+				float3 f3 = ColorIn.Load(int3(_214, _1191, 0)).rgb;
+				float3 c3 = ColorIn.Load(int3(_250, _1177, 0)).rgb;
+				float3 g3 = ColorIn.Load(int3(_250, _1191, 0)).rgb;
+				float3 h3 = ColorIn.Load(int3(_272, _1191, 0)).rgb;
+				float3 i3 = ColorIn.Load(int3(_228, _1225, 0)).rgb;
+				float3 j3 = ColorIn.Load(int3(_214, _1225, 0)).rgb;
+				float3 n3 = ColorIn.Load(int3(_214, _1239, 0)).rgb;
+				float3 k3 = ColorIn.Load(int3(_250, _1225, 0)).rgb;
+				float3 l3 = ColorIn.Load(int3(_272, _1225, 0)).rgb;
+				float3 o3 = ColorIn.Load(int3(_250, _1239, 0)).rgb;
+
+				b3 = PrepareForProcessing(b3);
+				c3 = PrepareForProcessing(c3);
+				e3 = PrepareForProcessing(e3);
+				f3 = PrepareForProcessing(f3);
+				g3 = PrepareForProcessing(g3);
+				h3 = PrepareForProcessing(h3);
+				i3 = PrepareForProcessing(i3);
+				j3 = PrepareForProcessing(j3);
+				k3 = PrepareForProcessing(k3);
+				l3 = PrepareForProcessing(l3);
+				n3 = PrepareForProcessing(n3);
+				o3 = PrepareForProcessing(o3);
+
+			  float3 _1619 = min(min(b3, min(e3, f3)), min(g3, j3));
+			  float3 _1635 = min(min(c3, min(f3, g3)), min(h3, k3));
+			  float3 _1651 = min(min(f3, min(i3, j3)), min(k3, n3));
+			  float3 _1667 = min(min(g3, min(j3, k3)), min(l3, o3));
+
+			  float3 _1627 = max(max(b3, max(e3, f3)), max(g3, j3));
+			  float3 _1643 = max(max(c3, max(f3, g3)), max(h3, k3));
+			  float3 _1659 = max(max(f3, max(i3, j3)), max(k3, n3));
+			  float3 _1675 = max(max(g3, max(j3, k3)), max(l3, o3));
+
+				float3 _1685 = 1.f - _1627;
+				float3 _1693 = 1.f - _1643;
+				float3 _1701 = 1.f - _1659;
+				float3 _1709 = 1.f - _1675;
+
+				float3 _1689 = 1.f / _1627;
+				float3 _1697 = 1.f / _1643;
+				float3 _1705 = 1.f / _1659;
+				float3 _1713 = 1.f / _1675;
+
+				_1689 *= min(_1619, _1685);
+				_1697 *= min(_1635, _1693);
+				_1705 *= min(_1651, _1701);
+				_1713 *= min(_1667, _1709);
+
+				float3 _3075 = saturate(_1689);
+				float3 _3107 = saturate(_1697);
+				float3 _3139 = saturate(_1705);
+				float3 _3171 = saturate(_1713);
+
+				float3 _1748 = 0.03125f - _1619;
+				float3 _1756 = 0.03125f - _1635;
+				float3 _1764 = 0.03125f - _1651;
+				float3 _1772 = 0.03125f - _1667;
+
+				_1748 += _1627;
+				_1756 += _1643;
+				_1764 += _1659;
+				_1772 += _1675;
+
+				_1748 = 1.f / _1748;
+				_1756 = 1.f / _1756;
+				_1764 = 1.f / _1764;
+				_1772 = 1.f / _1772;
+
+				_1748 *= _1732 * _700;
+				_1756 *= _1732 * _208;
+				_1764 *= _1159 * _700;
+				_1772 *= _1159 * _208;
+
+				float3 _1774 = sqrt(_3075);
+				float3 _1776 = sqrt(_3107);
+				float3 _1778 = sqrt(_3139);
+				float3 _1784 = sqrt(_3171);
+
+				_1774 *= sharp;
+				_1776 *= sharp;
+				_1778 *= sharp;
+				_1784 *= sharp;
+
+				_1774 *= _1748;
+				_1776 *= _1756;
+				_1778 *= _1764;
+				_1784 *= _1772;
+
+				float3 _1782 = (_1776 + _1748) + _1778;
+				float3 _1788 = (_1756 + _1774) + _1784;
+				float3 _1792 = (_1764 + _1774) + _1784;
+				float3 _1796 = (_1778 + _1776) + _1772;
+
+				float3 _1814 = 1.f / (((_1776 + _1774 + _1778 + _1784) * 2.f) + _1796 + _1782 + _1788 + _1792);
+
+				float3 colorOut3 = ((((((((f3 * _1782) + ((e3 + b3) * _1774)) + (k3 * _1796)) + (g3 * _1788)) + (j3 * _1792)) + ((o3 + l3) * _1784)) + ((n3 + i3) * _1778)) + ((h3 + c3) * _1776)) * _1814;
+
+				colorOut3 = PrepareForOutput(colorOut3);
+
+				ColorOut[uint2(_1119, _1153)] = float4(colorOut3, 1.f);
+			}
+		}
+
+		if (testY1)
+		{
+			float3 b2 = ColorIn.Load(int3(_114, _1177, 0)).rgb;
+			float3 e2 = ColorIn.Load(int3(_131, _1191, 0)).rgb;
+			float3 f2 = ColorIn.Load(int3(_114, _1191, 0)).rgb;
+			float3 c2 = ColorIn.Load(int3(_148, _1177, 0)).rgb;
+			float3 g2 = ColorIn.Load(int3(_148, _1191, 0)).rgb;
+			float3 h2 = ColorIn.Load(int3(_163, _1191, 0)).rgb;
+			float3 i2 = ColorIn.Load(int3(_131, _1225, 0)).rgb;
+			float3 j2 = ColorIn.Load(int3(_114, _1225, 0)).rgb;
+			float3 n2 = ColorIn.Load(int3(_114, _1239, 0)).rgb;
+			float3 k2 = ColorIn.Load(int3(_148, _1225, 0)).rgb;
+			float3 l2 = ColorIn.Load(int3(_163, _1225, 0)).rgb;
+			float3 o2 = ColorIn.Load(int3(_148, _1239, 0)).rgb;
+
+			b2 = PrepareForProcessing(b2);
+			c2 = PrepareForProcessing(c2);
+			e2 = PrepareForProcessing(e2);
+			f2 = PrepareForProcessing(f2);
+			g2 = PrepareForProcessing(g2);
+			h2 = PrepareForProcessing(h2);
+			i2 = PrepareForProcessing(i2);
+			j2 = PrepareForProcessing(j2);
+			k2 = PrepareForProcessing(k2);
+			l2 = PrepareForProcessing(l2);
+			n2 = PrepareForProcessing(n2);
+			o2 = PrepareForProcessing(o2);
+
+		  float3 _1618 = min(min(b2, min(e2, f2)), min(g2, j2));
+		  float3 _1634 = min(min(c2, min(f2, g2)), min(h2, k2));
+		  float3 _1650 = min(min(f2, min(i2, j2)), min(k2, n2));
+		  float3 _1666 = min(min(g2, min(j2, k2)), min(l2, o2));
+
+		  float3 _1626 = max(max(b2, max(e2, f2)), max(g2, j2));
+		  float3 _1642 = max(max(c2, max(f2, g2)), max(h2, k2));
+		  float3 _1658 = max(max(f2, max(i2, j2)), max(k2, n2));
+		  float3 _1674 = max(max(g2, max(j2, k2)), max(l2, o2));
+
+			float3 _1684 = 1.f - _1626;
+			float3 _1692 = 1.f - _1642;
+			float3 _1700 = 1.f - _1658;
+			float3 _1708 = 1.f - _1674;
+
+			float3 _1688 = 1.f / _1626;
+			float3 _1696 = 1.f / _1642;
+			float3 _1704 = 1.f / _1658;
+			float3 _1712 = 1.f / _1674;
+
+			_1688 *= min(_1618, _1684);
+			_1696 *= min(_1634, _1692);
+			_1704 *= min(_1650, _1700);
+			_1712 *= min(_1666, _1708);
+
+			float3 _3064 = saturate(_1688);
+			float3 _3096 = saturate(_1696);
+			float3 _3128 = saturate(_1704);
+			float3 _3160 = saturate(_1712);
+
+			float3 _1747 = 0.03125f - _1618;
+			float3 _1755 = 0.03125f - _1634;
+			float3 _1763 = 0.03125f - _1650;
+			float3 _1771 = 0.03125f - _1666;
+
+			_1747 += _1626;
+			_1755 += _1642;
+			_1763 += _1658;
+			_1771 += _1674;
+
+			_1747 = 1.f / _1747;
+			_1755 = 1.f / _1755;
+			_1763 = 1.f / _1763;
+			_1771 = 1.f / _1771;
+
+			_1747 *= _1732 * _699;
+			_1755 *= _1732 *  _91;
+			_1763 *= _1159 * _699;
+			_1771 *= _1159 *  _91;
+
+			float3 _1773 = sqrt(_3064);
+			float3 _1775 = sqrt(_3096);
+			float3 _1777 = sqrt(_3128);
+			float3 _1783 = sqrt(_3160);
+
+			_1773 *= sharp;
+			_1775 *= sharp;
+			_1777 *= sharp;
+			_1783 *= sharp;
+
+			_1773 *= _1747;
+			_1775 *= _1755;
+			_1777 *= _1763;
+			_1783 *= _1771;
+
+			float3 _1780 = (_1775 + _1747) + _1777;
+			float3 _1786 = (_1755 + _1773) + _1783;
+			float3 _1790 = (_1763 + _1773) + _1783;
+			float3 _1795 = (_1777 + _1775) + _1771;
+
+			float3 _1813 = 1.f / (((_1775 + _1773 + _1777 + _1783) * 2.f) + _1795 + _1780 + _1786 + _1790);
+
+			float3 colorOut2 = ((((((((f2 * _1780) + ((e2 + b2) * _1773)) + (g2 * _1786)) + (j2 * _1790)) + (k2 * _1795)) + ((o2 + l2) * _1783)) + ((n2 + i2) * _1777)) + ((h2 + c2) * _1775)) * _1813;
+
+			colorOut2 = PrepareForOutput(colorOut2);
+
+			ColorOut[uint2(_58, _1153)] = float4(colorOut2, 1.f);
+		}
 	}
 
 #elif defined(USE_PACKED_MATH) \
   && !defined(USE_UPSCALING)
+
+// "FP16" CAS sharpening
+
 #if 0 // Disable the CS so it just outputs the input
 	uint2 _55 = CASData.rectLimits0.xy;
 	uint _58 = _55.x + (((csInput.SV_GroupThreadID.x >> 1u) & 7u) | (csInput.SV_GroupID.x << 4u));
@@ -753,162 +677,152 @@ void CS(CSInput csInput)
 	         | (csInput.SV_GroupID.y << 4);
 	_59 += _55.y;
 
-	uint4 _71 = CASData.rectLimits1;
+	static const bool testX0 = _58 <= _55.z;
+	static const bool testY0 = _59 <= _55.w;
 
-	//unpack sharp stored as half
-	static const half hSharp = f16tof32(CASData.upscalingConst1.sharpAsHalf & 0xFFFF);
-
-	uint minX = _71.x;
-	uint minY = _71.y;
-	uint maxX = _71.z;
-	uint maxY = _71.w;
-
-	uint  _89 = clamp(_58,     minX, maxX);
-	uint _100 = clamp(_58 - 1, minX, maxX);
-	uint _120 = clamp(_58 + 1, minX, maxX);
-
-	uint _108 = clamp(_59,     minY, maxY);
-	uint  _91 = clamp(_59 - 1, minY, maxY);
-	uint _133 = clamp(_59 + 1, minY, maxY);
-
-	uint _156 = _58 + 7;
-	uint _141 = _58 + 8;
-	uint _179 = _58 + 9;
-
-	uint _157 = clamp(_156, minX, maxX);
-	uint _145 = clamp(_141, minX, maxX);
-	uint _180 = clamp(_179, minX, maxX);
-
-	half3  _93 = half3(ColorIn.Load(int3( _89,  _91, 0)).rgb);
-	half3 _109 = half3(ColorIn.Load(int3(_100, _108, 0)).rgb);
-	half3 _113 = half3(ColorIn.Load(int3( _89, _108, 0)).rgb);
-	half3 _124 = half3(ColorIn.Load(int3(_120, _108, 0)).rgb);
-	half3 _134 = half3(ColorIn.Load(int3( _89, _133, 0)).rgb);
-	half3 _146 = half3(ColorIn.Load(int3(_145,  _91, 0)).rgb);
-	half3 _161 = half3(ColorIn.Load(int3(_157, _108, 0)).rgb);
-	half3 _169 = half3(ColorIn.Load(int3(_145, _108, 0)).rgb);
-	half3 _184 = half3(ColorIn.Load(int3(_180, _108, 0)).rgb);
-	half3 _192 = half3(ColorIn.Load(int3(_145, _133, 0)).rgb);
-
-	 _93 = PrepareForProcessing( _93);
-	_109 = PrepareForProcessing(_109);
-	_113 = PrepareForProcessing(_113);
-	_124 = PrepareForProcessing(_124);
-	_134 = PrepareForProcessing(_134);
-	_146 = PrepareForProcessing(_146);
-	_161 = PrepareForProcessing(_161);
-	_169 = PrepareForProcessing(_169);
-	_184 = PrepareForProcessing(_184);
-	_192 = PrepareForProcessing(_192);
-
-	half _215 =  _93.y;
-	half _216 = _146.y;
-	half _235 = _109.y;
-	half _236 = _161.y;
-	half _255 = _113.y;
-	half _256 = _169.y;
-	half _275 = _124.y;
-	half _276 = _184.y;
-	half _295 = _134.y;
-	half _296 = _192.y;
-
-	half _316 = max(max(_275, _295), max(max(_215, _235), _255));
-	half _317 = max(max(_276, _296), max(max(_216, _236), _256));
-
-	half _338 = hSharp * sqrt(saturate(min(min(min(_275, _295), min(min(_215, _235), _255)), 1.h - _316) * (1.h / _316)));
-	half _339 = hSharp * sqrt(saturate(min(min(min(_276, _296), min(min(_216, _236), _256)), 1.h - _317) * (1.h / _317)));
-
-	half _345 = 1.h / ((_338 * 4.h) + 1.h);
-	half _346 = 1.h / ((_339 * 4.h) + 1.h);
-
-	if ((_58 <= _55.z) && (_59 <= _55.w))
+	if (testX0 && testY0)
 	{
-		half3 colorOut = (((_109 + _93 + _124 + _134) * _338) + _113) * _345;
+		uint _495 = _58 + 8;
+		uint _529 = _59 + 8;
 
-		colorOut = conditionalSaturate(colorOut);
-		colorOut = PrepareForOutput(colorOut);
+		uint4 _71 = CASData.rectLimits1;
 
-		ColorOut[uint2(_58, _59)] = float4(float3(colorOut), 1.f);
-	}
+		uint minX = _71.x;
+		uint minY = _71.y;
+		uint maxX = _71.z;
+		uint maxY = _71.w;
 
-	uint _495 = _58 + 8;
+		static const float sharp = CASData.upscalingConst1.sharp;
 
-	if ((_495 <= _55.z) && (_59 <= _55.w))
-	{
-		half3 colorOut = (((_161 + _146 + _184 + _192) * _339) + _169) * _346;
+		uint _100 = clamp(_58 - 1, minX, maxX);
+		uint  _89 = clamp(_58,     minX, maxX);
+		uint _120 = clamp(_58 + 1, minX, maxX);
 
-		colorOut = conditionalSaturate(colorOut);
-		colorOut = PrepareForOutput(colorOut);
+		uint  _91 = clamp(_59 - 1, minY, maxY);
+		uint _108 = clamp(_59,     minY, maxY);
+		uint _133 = clamp(_59 + 1, minY, maxY);
 
-		ColorOut[uint2(_495, _59)] = float4(float3(colorOut), 1.f);
-	}
+		uint _157 = clamp(_495 - 1, minX, maxX);
+		uint _145 = clamp(_495,     minX, maxX);
+		uint _180 = clamp(_495 + 1, minX, maxX);
 
-	uint _529 = _59 + 8;
+		uint _547 = clamp(_529 - 1, minY, maxY);
+		uint _561 = clamp(_529,     minY, maxY);
+		uint _583 = clamp(_529 + 1, minY, maxY);
 
-	uint _561 = clamp(_529,     minY, maxY);
-	uint _547 = clamp(_529 - 1, minY, maxY);
-	uint _583 = clamp(_529 + 1, minY, maxY);
 
-	half3 _549 = half3(ColorIn.Load(int3( _89, _547, 0)).rgb);
-	half3 _562 = half3(ColorIn.Load(int3(_100, _561, 0)).rgb);
-	half3 _566 = half3(ColorIn.Load(int3( _89, _561, 0)).rgb);
-	half3 _574 = half3(ColorIn.Load(int3(_120, _561, 0)).rgb);
-	half3 _584 = half3(ColorIn.Load(int3( _89, _583, 0)).rgb);
-	half3 _592 = half3(ColorIn.Load(int3(_145, _547, 0)).rgb);
-	half3 _604 = half3(ColorIn.Load(int3(_157, _561, 0)).rgb);
-	half3 _612 = half3(ColorIn.Load(int3(_145, _561, 0)).rgb);
-	half3 _624 = half3(ColorIn.Load(int3(_180, _561, 0)).rgb);
-	half3 _632 = half3(ColorIn.Load(int3(_145, _583, 0)).rgb);
+		float3 b0 = ColorIn.Load(int3( _89,  _91, 0)).rgb;
+		float3 d0 = ColorIn.Load(int3(_100, _108, 0)).rgb;
+		float3 e0 = ColorIn.Load(int3( _89, _108, 0)).rgb;
+		float3 f0 = ColorIn.Load(int3(_120, _108, 0)).rgb;
+		float3 h0 = ColorIn.Load(int3( _89, _133, 0)).rgb;
 
-	_549 = PrepareForProcessing(_549);
-	_562 = PrepareForProcessing(_562);
-	_566 = PrepareForProcessing(_566);
-	_574 = PrepareForProcessing(_574);
-	_584 = PrepareForProcessing(_584);
-	_592 = PrepareForProcessing(_592);
-	_604 = PrepareForProcessing(_604);
-	_612 = PrepareForProcessing(_612);
-	_624 = PrepareForProcessing(_624);
-	_632 = PrepareForProcessing(_632);
+		b0 = PrepareForProcessing(b0);
+		d0 = PrepareForProcessing(d0);
+		e0 = PrepareForProcessing(e0);
+		f0 = PrepareForProcessing(f0);
+		h0 = PrepareForProcessing(h0);
 
-	half _657 = _549.y;
-	half _658 = _592.y;
-	half _677 = _562.y;
-	half _678 = _604.y;
-	half _697 = _566.y;
-	half _698 = _612.y;
-	half _717 = _574.y;
-	half _718 = _624.y;
-	half _737 = _584.y;
-	half _738 = _632.y;
+		float3 maxRGB0 = max(max(f0, h0), max(max(b0, d0), e0));
+		float3 minRGB0 = min(min(f0, h0), min(min(b0, d0), e0));
 
-	half _758 = max(max(_717, _737), max(max(_657, _677), _697));
-	half _759 = max(max(_718, _738), max(max(_658, _678), _698));
+		float3 weight0 = sharp * sqrt(saturate(min(minRGB0, 1.f - maxRGB0) * (1.f / maxRGB0)));
 
-	half _772 = hSharp * sqrt(saturate(min(min(min(_717, _737), min(min(_657, _677), _697)), 1.h - _758) * (1.h / _758)));
-	half _773 = hSharp * sqrt(saturate(min(min(min(_718, _738), min(min(_658, _678), _698)), 1.h - _759) * (1.h / _759)));
+		float3 rcpWeight0 = 1.f / ((weight0 * 4.f) + 1.f);
 
-	half _778 = 1.h / ((_772 * 4.h) + 1.h);
-	half _779 = 1.h / ((_773 * 4.h) + 1.h);
+		float3 colorOut0 = (((d0 + b0 + f0 + h0) * weight0) + e0) * rcpWeight0;
 
-	if ((_58 <= _55.z) && (_529 <= _55.w))
-	{
-		half3 colorOut = (((_562 + _549 + _574 + _584) * _772) + _566) * _778;
+		colorOut0 = PrepareForOutput(colorOut0);
 
-		colorOut = conditionalSaturate(colorOut);
-		colorOut = PrepareForOutput(colorOut);
+		ColorOut[uint2(_58, _59)] = float4(colorOut0, 1.f);
 
-		ColorOut[uint2(_58, _529)] = float4(float3(colorOut), 1.f);
-	}
 
-	if ((_495 <= _55.z) && (_529 <= _55.w))
-	{
-		half3 colorOut = (((_604 + _592 + _624 + _632) * _773) + _612) * _779;
+		static const bool testX1 = _495 <= _55.z;
+		static const bool testY1 = _529 <= _55.w;
 
-		colorOut = conditionalSaturate(colorOut);
-		colorOut = PrepareForOutput(colorOut);
+		if (testX1)
+		{
+			float3 b1 = ColorIn.Load(int3(_145,  _91, 0)).rgb;
+			float3 d1 = ColorIn.Load(int3(_157, _108, 0)).rgb;
+			float3 e1 = ColorIn.Load(int3(_145, _108, 0)).rgb;
+			float3 f1 = ColorIn.Load(int3(_180, _108, 0)).rgb;
+			float3 h1 = ColorIn.Load(int3(_145, _133, 0)).rgb;
 
-		ColorOut[uint2(_495, _529)] = float4(float3(colorOut), 1.f);
+			b1 = PrepareForProcessing(b1);
+			d1 = PrepareForProcessing(d1);
+			e1 = PrepareForProcessing(e1);
+			f1 = PrepareForProcessing(f1);
+			h1 = PrepareForProcessing(h1);
+
+			float3 maxRGB1 = max(max(f1, h1), max(max(b1, d1), e1));
+			float3 minRGB1 = min(min(f1, h1), min(min(b1, d1), e1));
+
+			float3 weight1 = sharp * sqrt(saturate(min(minRGB1, 1.f - maxRGB1) * (1.f / maxRGB1)));
+
+			float3 rcpWeight1 = 1.f / ((weight1 * 4.f) + 1.f);
+
+			float3 colorOut1 = (((d1 + b1 + f1 + h1) * weight1) + e1) * rcpWeight1;
+
+			colorOut1 = PrepareForOutput(colorOut1);
+
+			ColorOut[uint2(_495, _59)] = float4(colorOut1, 1.f);
+
+			if (testY1)
+			{
+				float3 b3 = ColorIn.Load(int3(_145, _547, 0)).rgb;
+				float3 d3 = ColorIn.Load(int3(_157, _561, 0)).rgb;
+				float3 e3 = ColorIn.Load(int3(_145, _561, 0)).rgb;
+				float3 f3 = ColorIn.Load(int3(_180, _561, 0)).rgb;
+				float3 h3 = ColorIn.Load(int3(_145, _583, 0)).rgb;
+
+				d3 = PrepareForProcessing(d3);
+				b3 = PrepareForProcessing(b3);
+				e3 = PrepareForProcessing(e3);
+				f3 = PrepareForProcessing(f3);
+				h3 = PrepareForProcessing(h3);
+
+				float3 maxRGB3 = max(max(f3, h3), max(max(b3, d3), e3));
+				float3 minRGB3 = min(min(f3, h3), min(min(b3, d3), e3));
+
+				float3 weight3 = sharp * sqrt(saturate(min(minRGB3, 1.f - maxRGB3) * (1.f / maxRGB3)));
+
+				float3 rcpWeight3 = 1.f / ((weight3 * 4.f) + 1.f);
+
+				float3 colorOut3 = (((d3 + b3 + f3 + h3) * weight3) + e3) * rcpWeight3;
+
+				colorOut3 = PrepareForOutput(colorOut3);
+
+				ColorOut[uint2(_495, _529)] = float4(colorOut3, 1.f);
+			}
+		}
+
+		if (testY1)
+		{
+			float3 b2 = ColorIn.Load(int3( _89, _547, 0)).rgb;
+			float3 d2 = ColorIn.Load(int3(_100, _561, 0)).rgb;
+			float3 e2 = ColorIn.Load(int3( _89, _561, 0)).rgb;
+			float3 f2 = ColorIn.Load(int3(_120, _561, 0)).rgb;
+			float3 h2 = ColorIn.Load(int3( _89, _583, 0)).rgb;
+
+			b2 = PrepareForProcessing(b2);
+			d2 = PrepareForProcessing(d2);
+			e2 = PrepareForProcessing(e2);
+			f2 = PrepareForProcessing(f2);
+			h2 = PrepareForProcessing(h2);
+
+			float3 maxRGB2 = max(max(f2, h2), max(max(b2, d2), e2));
+			float3 minRGB2 = min(min(f2, h2), min(min(b2, d2), e2));
+
+			float3 weight2 = sharp * sqrt(saturate(min(minRGB2, 1.f - maxRGB2) * (1.f / maxRGB2)));
+
+			float3 rcpWeight2 = 1.f / ((weight2 * 4.f) + 1.f);
+
+			float3 colorOut2 = (((d2 + b2 + f2 + h2) * weight2) + e2) * rcpWeight2;
+
+			colorOut2 = PrepareForOutput(colorOut2);
+
+			ColorOut[uint2(_58, _529)] = float4(colorOut2, 1.f);
+		}
 	}
 
 #endif

--- a/shaders/ContrastAdaptiveSharpening/ContrastAdaptiveSharpening_cs.hlsl
+++ b/shaders/ContrastAdaptiveSharpening/ContrastAdaptiveSharpening_cs.hlsl
@@ -826,5 +826,167 @@ void CS(CSInput csInput)
 	}
 
 #endif
-#endif // USE_PACKED_MATH
+#else
+
+// FP32 CAS sharpening
+
+	uint4 _55 = CASData.rectLimits0;
+
+	uint _58 = ((csInput.SV_GroupThreadID.x >> 1) & 7)
+	         | (csInput.SV_GroupID.x << 4);
+	_58 += _55.x;
+
+	uint _59 = ((csInput.SV_GroupThreadID.x >> 3) & 6)
+	         | (csInput.SV_GroupThreadID.x & 1)
+	         | (csInput.SV_GroupID.y << 4);
+	_59 += _55.y;
+
+	static const bool testX0 = _58 <= _55.z;
+	static const bool testY0 = _59 <= _55.w;
+
+	if (testX0 && testY0)
+	{
+		uint _285 = _58 + 8;
+		uint _492 = _59 + 8;
+
+		static const float sharp = CASData.upscalingConst1.sharp;
+
+		uint4 _68 = CASData.rectLimits1;
+
+		uint minX = _68.x;
+		uint minY = _68.y;
+		uint maxX = _68.z;
+		uint maxY = _68.w;
+
+		uint _83 = CLAMPX(_58 - 1);
+		uint _76 = CLAMPX(_58);
+		uint _94 = CLAMPX(_58 + 1);
+
+		uint  _64 = CLAMPY(_59 - 1);
+		uint  _87 = CLAMPY(_59);
+		uint _100 = CLAMPY(_59 + 1);
+
+		uint _301 = CLAMPX(_285 - 1);
+		uint _295 = CLAMPX(_285);
+		uint _312 = CLAMPX(_285 + 1);
+
+		uint _513 = CLAMPY(_492 - 1);
+		uint _512 = CLAMPY(_492);
+		uint _514 = CLAMPY(_492 + 1);
+
+		float3 b0 = ColorIn.Load(int3(_76,  _64, 0)).rgb;
+		float3 d0 = ColorIn.Load(int3(_83,  _87, 0)).rgb;
+		float3 e0 = ColorIn.Load(int3(_76,  _87, 0)).rgb;
+		float3 f0 = ColorIn.Load(int3(_94,  _87, 0)).rgb;
+		float3 h0 = ColorIn.Load(int3(_76, _100, 0)).rgb;
+
+		b0 = PrepareForProcessing(b0);
+		d0 = PrepareForProcessing(d0);
+		e0 = PrepareForProcessing(e0);
+		f0 = PrepareForProcessing(f0);
+		h0 = PrepareForProcessing(h0);
+
+		float3 maxRGB0 = max(max(d0, max(e0, f0)), max(b0, h0));
+		float3 minRGB0 = min(min(d0, min(e0, f0)), min(b0, h0));
+
+		float3 weight0 = sharp * sqrt(saturate(min(minRGB0, 1.f - maxRGB0) * (1.f / maxRGB0)));
+
+		float3 rcpWeight0 = 1.f / ((weight0 * 4.f) + 1.f);
+
+		float3 colorOut0 = (((d0 + b0 + f0 + h0) * weight0) + e0) * rcpWeight0;
+
+		colorOut0 = PrepareForOutput(colorOut0);
+
+		ColorOut[uint2(_58, _59)] = float4(colorOut0, 1.f);
+
+
+		static const bool testX1 = _285 <= _55.z;
+		static const bool testY1 = _492 <= _55.w;
+
+		if (testX1)
+		{
+			float3 b1 = ColorIn.Load(int3(_295,  _64, 0)).rgb;
+			float3 d1 = ColorIn.Load(int3(_301,  _87, 0)).rgb;
+			float3 e1 = ColorIn.Load(int3(_295,  _87, 0)).rgb;
+			float3 f1 = ColorIn.Load(int3(_312,  _87, 0)).rgb;
+			float3 h1 = ColorIn.Load(int3(_295, _100, 0)).rgb;
+
+			b1 = PrepareForProcessing(b1);
+			d1 = PrepareForProcessing(d1);
+			e1 = PrepareForProcessing(e1);
+			f1 = PrepareForProcessing(f1);
+			h1 = PrepareForProcessing(h1);
+
+			float3 maxRGB1 = max(max(d1, max(e1, f1)), max(b1, h1));
+			float3 minRGB1 = min(min(d1, min(e1, f1)), min(b1, h1));
+
+			float3 weight1 = sharp * sqrt(saturate(min(minRGB1, 1.f - maxRGB1) * (1.f / maxRGB1)));
+
+			float3 rcpWeight1 = 1.f / ((weight1 * 4.f) + 1.f);
+
+			float3 colorOut1 = (((d1 + b1 + f1 + h1) * weight1) + e1) * rcpWeight1;
+
+			colorOut1 = PrepareForOutput(colorOut1);
+
+			ColorOut[uint2(_285, _59)] = float4(colorOut1, 1.f);
+
+			if (testY1)
+			{
+				float3 b2 = ColorIn.Load(int3(_295, _513, 0)).rgb;
+				float3 d2 = ColorIn.Load(int3(_301, _512, 0)).rgb;
+				float3 e2 = ColorIn.Load(int3(_295, _512, 0)).rgb;
+				float3 f2 = ColorIn.Load(int3(_312, _512, 0)).rgb;
+				float3 h2 = ColorIn.Load(int3(_295, _514, 0)).rgb;
+
+				b2 = PrepareForProcessing(b2);
+				d2 = PrepareForProcessing(d2);
+				e2 = PrepareForProcessing(e2);
+				f2 = PrepareForProcessing(f2);
+				h2 = PrepareForProcessing(h2);
+
+				float3 maxRGB2 = max(max(d2, max(e2, f2)), max(b2, h2));
+				float3 minRGB2 = min(min(d2, min(e2, f2)), min(b2, h2));
+
+				float3 weight2 = sharp * sqrt(saturate(min(minRGB2, 1.f - maxRGB2) * (1.f / maxRGB2)));
+
+				float3 rcpWeight2 = 1.f / ((weight2 * 4.f) + 1.f);
+
+				float3 colorOut2 = (((d2 + b2 + f2 + h2) * weight2) + e2) * rcpWeight2;
+
+				colorOut2 = PrepareForOutput(colorOut2);
+
+				ColorOut[uint2(_285, _492)] = float4(colorOut2, 1.f);
+			}
+		}
+
+		if (testY1)
+		{
+			float3 b3 = ColorIn.Load(int3(_76, _513, 0)).rgb;
+			float3 d3 = ColorIn.Load(int3(_83, _512, 0)).rgb;
+			float3 e3 = ColorIn.Load(int3(_76, _512, 0)).rgb;
+			float3 f3 = ColorIn.Load(int3(_94, _512, 0)).rgb;
+			float3 h3 = ColorIn.Load(int3(_76, _514, 0)).rgb;
+
+			b3 = PrepareForProcessing(b3);
+			d3 = PrepareForProcessing(d3);
+			e3 = PrepareForProcessing(e3);
+			f3 = PrepareForProcessing(f3);
+			h3 = PrepareForProcessing(h3);
+
+			float3 maxRGB3 = max(max(d3, max(e3, f3)), max(b3, h3));
+			float3 minRGB3 = min(min(d3, min(e3, f3)), min(b3, h3));
+
+			float3 weight3 = sharp * sqrt(saturate(min(minRGB3, 1.f - maxRGB3) * (1.f / maxRGB3)));
+
+			float3 rcpWeight3 = 1.f / ((weight3 * 4.f) + 1.f);
+
+			float3 colorOut3 = (((d3 + b3 + f3 + h3) * weight3) + e3) * rcpWeight3;
+
+			colorOut3 = PrepareForOutput(colorOut3);
+
+			ColorOut[uint2(_58, _492)] = float4(colorOut3, 1.f);
+		}
+	}
+
+#endif
 }

--- a/shaders/compile_all_shaders.ps1
+++ b/shaders/compile_all_shaders.ps1
@@ -32,6 +32,7 @@ $main =
 	#ContrastAdaptiveSharpening
 	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "1FE95"
 	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "201FE95" -Defines "USE_PACKED_MATH" #-AdditionalParams "-enable-16bit-types", "-Wno-conversion"
+	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "401FE95" -Defines "USE_UPSCALING"
 	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "601FE95" -Defines "USE_PACKED_MATH", "USE_UPSCALING" #-AdditionalParams "-enable-16bit-types", "-Wno-conversion"
 
 	#PostSharpen

--- a/shaders/compile_all_shaders.ps1
+++ b/shaders/compile_all_shaders.ps1
@@ -31,8 +31,8 @@ $main =
 
 	#ContrastAdaptiveSharpening
 	#Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "1FE95" -Entry "main"
-	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "201FE95" -Defines "USE_PACKED_MATH" -AdditionalParams "-enable-16bit-types", "-Wno-conversion"
-	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "601FE95" -Defines "USE_PACKED_MATH", "USE_UPSCALING" -AdditionalParams "-enable-16bit-types", "-Wno-conversion"
+	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "201FE95" -Defines "USE_PACKED_MATH" #-AdditionalParams "-enable-16bit-types", "-Wno-conversion"
+	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "601FE95" -Defines "USE_PACKED_MATH", "USE_UPSCALING" #-AdditionalParams "-enable-16bit-types", "-Wno-conversion"
 
 	#PostSharpen
 	Compile-Shader -Type "ps" -TechniqueName "PostSharpen" -TechniqueId "1FE9B"

--- a/shaders/compile_all_shaders.ps1
+++ b/shaders/compile_all_shaders.ps1
@@ -30,7 +30,7 @@ $main =
 	Compile-Shader -Type "cs" -TechniqueName "ColorGradingMerge" -TechniqueId "1FE86" -OutputName "HDRColorGradingMerge"
 
 	#ContrastAdaptiveSharpening
-	#Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "1FE95" -Entry "main"
+	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "1FE95"
 	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "201FE95" -Defines "USE_PACKED_MATH" #-AdditionalParams "-enable-16bit-types", "-Wno-conversion"
 	Compile-Shader -Type "cs" -TechniqueName "ContrastAdaptiveSharpening" -TechniqueId "601FE95" -Defines "USE_PACKED_MATH", "USE_UPSCALING" #-AdditionalParams "-enable-16bit-types", "-Wno-conversion"
 


### PR DESCRIPTION
CAS needs to work in 0-1. 0-1 in fp16 (half) is not enough to store the whole range without loosing information to quantization. so I changed it to be in fp32.

ideally we switch to fp16 for SDR. though that is probably not worth it imho.

also some optimisation :)

missing 2 permutations are:
- CAS sharpening in FP32
- CAS upscaling in FP32