### PR TITLE
[WIP] 1.16.244 compatibility

### DIFF
--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -56,4 +56,4 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
       with:
-        path: D:\a\Starfield-Luma\Starfield-Luma\build
+        path: D:\a\Starfield-Luma\Starfield-Luma

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -39,7 +39,7 @@ jobs:
         # version database won't contain the package versions the baseline resolves to.
         vcpkgGitCommitId: '66affb04e3b889a3210f7f24bef2fa93a557fa62'
         vcpkgJsonGlob: '**/Plugin/vcpkg.json'
-      
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
@@ -52,3 +52,8 @@ jobs:
     - name: Build
       # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config Release
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        path: D:\a\Starfield-Luma\Starfield-Luma\build

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -56,4 +56,6 @@ jobs:
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
       with:
-        path: D:\a\Starfield-Luma\Starfield-Luma
+        name: Luma-packages
+        path: ${{ github.workspace }}/Plugin/dist/*.zip
+        if-no-files-found: error

--- a/.github/workflows/cmake-windows.yml
+++ b/.github/workflows/cmake-windows.yml
@@ -10,10 +10,12 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    # Pinned: `windows-latest` now maps to Windows Server 2025 + Visual Studio 2026,
+    # which no longer provides the "Visual Studio 17 2022" generator used by the presets.
+    runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Update submodules
       run: |
@@ -33,7 +35,9 @@ jobs:
     - name: Configure vcpkg
       uses: lukka/run-vcpkg@v11
       with:
-        vcpkgGitCommitId: 'a7d99a5c3cd1456af023051d025a5643a2d6e79c'
+        # Must match "builtin-baseline" in Plugin/vcpkg.json, otherwise the checked out
+        # version database won't contain the package versions the baseline resolves to.
+        vcpkgGitCommitId: '66affb04e3b889a3210f7f24bef2fa93a557fa62'
         vcpkgJsonGlob: '**/Plugin/vcpkg.json'
       
     - name: Configure CMake
@@ -41,8 +45,6 @@ jobs:
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
-        -DCMAKE_CXX_COMPILER=cl
-        -DCMAKE_C_COMPILER=cl
         -DCMAKE_BUILD_TYPE=Release
         -S ${{ github.workspace }}/Plugin
         --preset=build-release-msvc-msvc

--- a/Plugin/src/Hooks.h
+++ b/Plugin/src/Hooks.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Offsets.h"
 #include "Settings.h"
 #include "Utils.h"
 #include "RE/Buffers.h"
@@ -40,13 +41,23 @@ namespace Hooks
 	class Hooks
 	{
 	public:
+		// Resolves a hook site and checks it still holds a call before we patch over it. Offsets
+		// into a function move whenever the game is rebuilt, even when the address library id
+		// still points at the right function.
+		static std::uintptr_t CallSite(std::uint64_t a_id, std::ptrdiff_t a_offset, std::size_t a_size, std::string_view a_name)
+		{
+			const auto address = dku::Hook::IDToAbs(a_id, a_offset);
+			Offsets::IsCallSite(address, a_size, a_name);
+			return address;
+		}
+
 		static void Hook()
 		{
 			// set color space and save swapchain object pointer
-			_UnkFunc = dku::Hook::write_call<5>(dku::Hook::IDToAbs(143272, 0xAC9), Hook_UnkFunc);
+			_UnkFunc = dku::Hook::write_call<5>(CallSite(143272, 0xAC9, 5, "UnkFunc"), Hook_UnkFunc);
 
 			// just after loading ini settings; deal with initial framegen setting value
-			_UnkFunc2 = dku::Hook::write_call<5>(dku::Hook::IDToAbs(99482, 0x61D), Hook_UnkFunc2);
+			_UnkFunc2 = dku::Hook::write_call<5>(CallSite(99482, 0x61D, 5, "UnkFunc2"), Hook_UnkFunc2);
 
 			// disable photo mode screenshots with HDR
 			const auto takeSnapshotVtbl = dku::Hook::IDToAbs(443439);
@@ -55,13 +66,21 @@ namespace Hooks
 			_Hook_TakeSnapshot->Enable();
 
 			// Settings UI
-			_CreateMonitorSetting = dku::Hook::write_call<5>(dku::Hook::IDToAbs(88728, 0x121C), Hook_CreateMonitorSetting);
+			_CreateMonitorSetting = dku::Hook::write_call<5>(CallSite(88728, 0x121C, 5, "CreateMonitorSetting"), Hook_CreateMonitorSetting);
 
-			// Hide vanilla brightness, contrast and hdr brightness
+			// Hide vanilla brightness, contrast and hdr brightness. Only NOP these out once we know
+			// they are still the calls we expect - blanking five bytes of something else would
+			// corrupt the function rather than just fail.
 			const uint8_t nop5[] = { 0x90, 0x90, 0x90, 0x90, 0x90 };
-			dku::Hook::WriteData(dku::Hook::IDToAbs(88728, 0x1B2E), nop5, 5);
-			dku::Hook::WriteData(dku::Hook::IDToAbs(88728, 0x1DAA), nop5, 5);
-			dku::Hook::WriteData(dku::Hook::IDToAbs(88728, 0x209D), nop5, 5);
+			for (const auto& [offset, name] : std::initializer_list<std::pair<std::ptrdiff_t, std::string_view>>{
+					 { 0x1B2E, "HideVanillaBrightness" },
+					 { 0x1DAA, "HideVanillaContrast" },
+					 { 0x209D, "HideVanillaHDRBrightness" } }) {
+				const auto address = dku::Hook::IDToAbs(88728, offset);
+				if (Offsets::IsCallSite(address, 5, name)) {
+					dku::Hook::WriteData(address, nop5, 5);
+				}
+			}
 
 			const auto settingsDataModelCheckboxVtbl = dku::Hook::IDToAbs(439683);
 			const auto settingsDataModelStepperVtbl = dku::Hook::IDToAbs(439693);
@@ -79,29 +98,37 @@ namespace Hooks
 			hookSettingsDataModelStepper->Enable();
 			hookSettingsDataModelSlider->Enable();
 
-			_RecreateSwapchain = dku::Hook::write_call<5>(dku::Hook::IDToAbs(141998, 0xBF), Hook_RecreateSwapchain);
+			_RecreateSwapchain = dku::Hook::write_call<5>(CallSite(141998, 0xBF, 5, "RecreateSwapchain"), Hook_RecreateSwapchain);
 
-			_ApplyRenderPassRenderState1 = dku::Hook::write_call<5>(dku::Hook::IDToAbs(144651, 0x18), Hook_ApplyRenderPassRenderState1);  // CmdDraw
-			_ApplyRenderPassRenderState2 = dku::Hook::write_call<5>(dku::Hook::IDToAbs(144655, 0x20), Hook_ApplyRenderPassRenderState2);  // CmdDispatch
+			_ApplyRenderPassRenderState1 = dku::Hook::write_call<5>(CallSite(144651, 0x18, 5, "ApplyRenderPassRenderState1"), Hook_ApplyRenderPassRenderState1);  // CmdDraw
+			_ApplyRenderPassRenderState2 = dku::Hook::write_call<5>(CallSite(144655, 0x20, 5, "ApplyRenderPassRenderState2"), Hook_ApplyRenderPassRenderState2);  // CmdDispatch
 
-			_EndOfFrame = dku::Hook::write_call<5>(dku::Hook::IDToAbs(143152, 0xCBD), Hook_EndOfFrame);
-			_PostEndOfFrame = dku::Hook::write_call<5>(dku::Hook::IDToAbs(143152, 0x148F), Hook_PostEndOfFrame);  // CmdEnd, was CmdEndProfilingMarker previously
+			_EndOfFrame = dku::Hook::write_call<5>(CallSite(143152, 0xCBD, 5, "EndOfFrame"), Hook_EndOfFrame);
+			_PostEndOfFrame = dku::Hook::write_call<5>(CallSite(143152, 0x148F, 5, "PostEndOfFrame"), Hook_PostEndOfFrame);  // CmdEnd, was CmdEndProfilingMarker previously
 
 			const auto scaleformCompositeRenderPassVtbl = dku::Hook::IDToAbs(497272);
 			auto hookScaleformCompositeRenderPass = dku::Hook::AddVMTHook(&scaleformCompositeRenderPassVtbl, 7, FUNC_INFO(HookedScaleformCompositeRenderPass));
 			_ScaleformCompositeRenderPass = reinterpret_cast<decltype(&HookedScaleformCompositeRenderPass)>(hookScaleformCompositeRenderPass->OldAddress);
 			hookScaleformCompositeRenderPass->Enable();
-			dku::Hook::write_call<5>(hookScaleformCompositeRenderPass->OldAddress + 0x4A0, HookedScaleformCompositeRenderPassExecuteDraw);
+			const auto scaleformExecuteDrawSite = hookScaleformCompositeRenderPass->OldAddress + 0x4A0;
+			Offsets::IsCallSite(scaleformExecuteDrawSite, 5, "ScaleformCompositeRenderPassExecuteDraw");
+			dku::Hook::write_call<5>(scaleformExecuteDrawSite, HookedScaleformCompositeRenderPassExecuteDraw);
 
 			// fsr3 fixes
-			_ffxFsr3ContextCreate = dku::Hook::write_call<5>(dku::Hook::IDToAbs(144625, 0x374), Hook_ffxFsr3ContextCreate);
-			dku::Hook::write_call<6>(dku::Hook::IDToAbs(178624, 0x3CE), Hook_CreateShaderResourceView);
+			_ffxFsr3ContextCreate = dku::Hook::write_call<5>(CallSite(144625, 0x374, 5, "ffxFsr3ContextCreate"), Hook_ffxFsr3ContextCreate);
+			dku::Hook::write_call<6>(CallSite(178624, 0x3CE, 6, "CreateShaderResourceView"), Hook_CreateShaderResourceView);
 			//_UnkFunc3 = dku::Hook::write_call<5>(dku::Hook::IDToAbs(1078894, 0x5DB), Hook_UnkFunc3);  // mess
 			//_UnkFunc3_Internal = dku::Hook::write_call<5>(dku::Hook::IDToAbs(1722115, 0x113), Hook_UnkFunc3_Internal);  // mess
 
 			// Starfield immediately crashes because of an unhandled assertion when any D3D12 debug layer is active
 			// const uint8_t retn[] = { 0xC3 };
 			// dku::Hook::WriteData(dku::Hook::IDToAbs(140240), retn, 1);
+
+			if (const auto failures = Offsets::GetResolveFailureCount(); failures > 0) {
+				WARN("Hooks: finished with {} failed address validation(s) in total, expect broken or missing features", failures)
+			} else {
+				INFO("Hooks: all hook sites validated")
+			}
 		}
 
 	private:

--- a/Plugin/src/Offsets.h
+++ b/Plugin/src/Offsets.h
@@ -47,39 +47,156 @@ public:
 	static inline tGetSettingsDataModelParams GetSettingsDataModelStepperParams = nullptr;
 	static inline tGetSettingsDataModelParams GetSettingsDataModelSliderParams = nullptr;
 
+	// What a resolved address is expected to point at. Checked against the section it lands in.
+	enum class AddressKind
+	{
+		Code,      // a function, so an executable section
+		Data,      // a global, so a writable section
+		ReadOnly,  // a vtable or similar, so .rdata
+	};
+
+	// Address library IDs are regenerated for every game build, and a stale ID normally still
+	// resolves - to whatever unrelated thing now occupies that slot - so a bad port surfaces as a
+	// crash a long way from its cause. Sanity check every address and log the lot, so that after a
+	// game update the log alone says which IDs moved.
+	static std::uintptr_t Resolve(std::uint64_t a_id, AddressKind a_kind, std::string_view a_name)
+	{
+		const auto address = dku::Hook::IDToAbs(a_id);
+
+		const auto* section = FindSection(address);
+		if (!section) {
+			WARN("Offsets: {} (id {}) resolved to {:X}, which is outside every section", a_name, a_id, address)
+			++resolveFailures;
+			return address;
+		}
+
+		const bool executable = (section->Characteristics & IMAGE_SCN_MEM_EXECUTE) != 0;
+		const bool writable = (section->Characteristics & IMAGE_SCN_MEM_WRITE) != 0;
+
+		bool matches = false;
+		switch (a_kind) {
+		case AddressKind::Code:
+			matches = executable;
+			break;
+		case AddressKind::Data:
+			matches = writable && !executable;
+			break;
+		case AddressKind::ReadOnly:
+			matches = !writable && !executable;
+			break;
+		}
+
+		// Section names are not null terminated when they use all 8 bytes.
+		const std::string_view sectionName{ reinterpret_cast<const char*>(section->Name),
+			::strnlen(reinterpret_cast<const char*>(section->Name), sizeof(section->Name)) };
+
+		if (!matches) {
+			WARN("Offsets: {} (id {}) resolved to {:X} in {}, which is not the expected kind", a_name, a_id, address, sectionName)
+			++resolveFailures;
+		} else {
+			INFO("Offsets: {} (id {}) -> {:X} [{}]", a_name, a_id, address, sectionName)
+		}
+
+		return address;
+	}
+
+	// Hook sites are given as an offset into a function, and those offsets shift whenever the game
+	// is rebuilt even when the address library id still points at the right function. Every site we
+	// patch is a call, so check for one before overwriting it.
+	static bool IsCallSite(std::uintptr_t a_address, std::size_t a_size, std::string_view a_name)
+	{
+		// Guard the read: a badly moved offset can land outside the image entirely, and faulting
+		// here would defeat the point of checking.
+		const auto* section = FindSection(a_address);
+		if (!section || (section->Characteristics & IMAGE_SCN_MEM_EXECUTE) == 0) {
+			WARN("Offsets: hook site {} at {:X} is not in executable memory, the offset has moved", a_name, a_address)
+			++resolveFailures;
+			return false;
+		}
+
+		const auto* opcode = reinterpret_cast<const std::uint8_t*>(a_address);
+
+		// E8 is a direct call rel32 (5 bytes); FF /2 is an indirect call (6 bytes here).
+		const bool isCall = (a_size == 5 && opcode[0] == 0xE8) ||
+		                    (a_size == 6 && opcode[0] == 0xFF);
+
+		if (!isCall) {
+			WARN("Offsets: hook site {} at {:X} is not a {}-byte call (found {:02X}), the offset has moved", a_name, a_address, a_size, opcode[0])
+			++resolveFailures;
+		}
+
+		return isCall;
+	}
+
+	static std::uint32_t GetResolveFailureCount() { return resolveFailures; }
+
 	static void Initialize()
 	{
-		bufferArray = reinterpret_cast<BufferArray*>(dku::Hook::IDToAbs(370539));
-		GetDXGIFormat = reinterpret_cast<tGetDXGIFormat>(dku::Hook::IDToAbs(142460));
+		resolveFailures = 0;
 
-		ToggleVsync = reinterpret_cast<tToggleVsync>(dku::Hook::IDToAbs(128505));
-		unkToggleVsyncArg1Ptr = reinterpret_cast<uintptr_t*>(dku::Hook::IDToAbs(937583));
-		bEnableVsync = reinterpret_cast<bool*>(dku::Hook::IDToAbs(933467));
+		bufferArray = reinterpret_cast<BufferArray*>(Resolve(370539, AddressKind::ReadOnly, "bufferArray"));
+		GetDXGIFormat = reinterpret_cast<tGetDXGIFormat>(Resolve(142460, AddressKind::Code, "GetDXGIFormat"));
+
+		ToggleVsync = reinterpret_cast<tToggleVsync>(Resolve(128505, AddressKind::Code, "ToggleVsync"));
+		unkToggleVsyncArg1Ptr = reinterpret_cast<uintptr_t*>(Resolve(937583, AddressKind::Data, "unkToggleVsyncArg1Ptr"));
+		bEnableVsync = reinterpret_cast<bool*>(Resolve(933467, AddressKind::Data, "bEnableVsync"));
 
 		//MessageMenuManagerPtr = reinterpret_cast<void**>(dku::Hook::IDToAbs(878772));
 		//ShowMessageBox = reinterpret_cast<tShowMessageBox>(dku::Hook::IDToAbs(167094));
 
-		PhotoMode_ToggleUI = reinterpret_cast<tPhotoMode_ToggleUI>(dku::Hook::IDToAbs(92038));
+		PhotoMode_ToggleUI = reinterpret_cast<tPhotoMode_ToggleUI>(Resolve(92038, AddressKind::Code, "PhotoMode_ToggleUI"));
 
-		uiPtr = reinterpret_cast<UI**>(dku::Hook::IDToAbs(937580));
-		UI_IsMenuOpen = reinterpret_cast<tUI_IsMenuOpen>(dku::Hook::IDToAbs(130475));
+		uiPtr = reinterpret_cast<UI**>(Resolve(937580, AddressKind::Data, "uiPtr"));
+		UI_IsMenuOpen = reinterpret_cast<tUI_IsMenuOpen>(Resolve(130475, AddressKind::Code, "UI_IsMenuOpen"));
 
 		//unkToggleMenusPtr = reinterpret_cast<void**>(dku::Hook::IDToAbs(938533));
 		//ToggleMenus = reinterpret_cast<tToggleMenus>(dku::Hook::IDToAbs(130602));
 
-		g_deltaTimeRealTime = reinterpret_cast<float*>(dku::Hook::IDToAbs(936961));
-		g_durationOfApplicationRunTimeMS = reinterpret_cast<uint32_t*>(dku::Hook::IDToAbs(936963));
+		g_deltaTimeRealTime = reinterpret_cast<float*>(Resolve(936961, AddressKind::Data, "g_deltaTimeRealTime"));
+		g_durationOfApplicationRunTimeMS = reinterpret_cast<uint32_t*>(Resolve(936963, AddressKind::Data, "g_durationOfApplicationRunTimeMS"));
 
-		documentsPath = reinterpret_cast<const char*>(dku::Hook::IDToAbs(937452));
-		photosPath = reinterpret_cast<const char**>(dku::Hook::IDToAbs(828199));
+		documentsPath = reinterpret_cast<const char*>(Resolve(937452, AddressKind::Data, "documentsPath"));
+		photosPath = reinterpret_cast<const char**>(Resolve(828199, AddressKind::Data, "photosPath"));
 
-		fGamma = reinterpret_cast<float*>(dku::Hook::IDToAbs(933234));
-		fGammaUI = reinterpret_cast<float*>(dku::Hook::IDToAbs(933237));
-		uiUpscalingTechnique = reinterpret_cast<RE::UpscalingTechnique*>(dku::Hook::IDToAbs(933266));
-		uiFrameGenerationTech = reinterpret_cast<RE::FrameGenerationTech*>(dku::Hook::IDToAbs(933291));
+		fGamma = reinterpret_cast<float*>(Resolve(933234, AddressKind::Data, "fGamma"));
+		fGammaUI = reinterpret_cast<float*>(Resolve(933237, AddressKind::Data, "fGammaUI"));
+		uiUpscalingTechnique = reinterpret_cast<RE::UpscalingTechnique*>(Resolve(933266, AddressKind::Data, "uiUpscalingTechnique"));
+		uiFrameGenerationTech = reinterpret_cast<RE::FrameGenerationTech*>(Resolve(933291, AddressKind::Data, "uiFrameGenerationTech"));
 
-		GetSettingsDataModelCheckboxParams = reinterpret_cast<tGetSettingsDataModelParams>(dku::Hook::IDToAbs(88949));
-		GetSettingsDataModelStepperParams = reinterpret_cast<tGetSettingsDataModelParams>(dku::Hook::IDToAbs(88948));
-		GetSettingsDataModelSliderParams = reinterpret_cast<tGetSettingsDataModelParams>(dku::Hook::IDToAbs(88946));
+		GetSettingsDataModelCheckboxParams = reinterpret_cast<tGetSettingsDataModelParams>(Resolve(88949, AddressKind::Code, "GetSettingsDataModelCheckboxParams"));
+		GetSettingsDataModelStepperParams = reinterpret_cast<tGetSettingsDataModelParams>(Resolve(88948, AddressKind::Code, "GetSettingsDataModelStepperParams"));
+		GetSettingsDataModelSliderParams = reinterpret_cast<tGetSettingsDataModelParams>(Resolve(88946, AddressKind::Code, "GetSettingsDataModelSliderParams"));
+
+		if (resolveFailures > 0) {
+			WARN("Offsets: {} address(es) failed validation - this build of Luma likely does not match the running game version", resolveFailures)
+		} else {
+			INFO("Offsets: all addresses resolved and validated")
+		}
 	}
+
+private:
+	static const ::IMAGE_SECTION_HEADER* FindSection(std::uintptr_t a_address)
+	{
+		auto&       gameModule = dku::Hook::Module::get();
+		const auto  base = gameModule.base();
+		const auto* ntHeader = gameModule.ntHeader();
+
+		if (a_address < base) {
+			return nullptr;
+		}
+
+		const auto  rva = static_cast<std::uint32_t>(a_address - base);
+		const auto* section = gameModule.sectionHeader();
+
+		for (std::uint16_t i = 0; i < ntHeader->FileHeader.NumberOfSections; ++i, ++section) {
+			const auto size = section->Misc.VirtualSize ? section->Misc.VirtualSize : section->SizeOfRawData;
+			if (rva >= section->VirtualAddress && rva < section->VirtualAddress + size) {
+				return section;
+			}
+		}
+
+		return nullptr;
+	}
+
+	static inline std::uint32_t resolveFailures = 0;
 };

--- a/shaders/HDRComposite/HDRComposite_ps.hlsl
+++ b/shaders/HDRComposite/HDRComposite_ps.hlsl
@@ -248,8 +248,8 @@ T ACESParametric(
 	inout ACESParametricParams params
 )
 {
-	const float AcesParam0 = PerSceneConstants[3259u].x; // Constant is usually 11.2
-	const float AcesParam1 = PerSceneConstants[3259u].y; // Constant is usually 0.022
+	const float AcesParam0 = PerSceneConstants[3255u].x; // Constant is usually 11.2
+	const float AcesParam1 = PerSceneConstants[3255u].y; // Constant is usually 0.022
 
 	params.modE = AcesParam1;
 	params.modA = ((0.56f / AcesParam0) + ACES_b) + (AcesParam1 / (AcesParam0 * AcesParam0));
@@ -344,11 +344,11 @@ float3 Hable(
 
 	// Note that all these variables can vary depending on the level.
 	// The 2.2 pow is so you don't have to input very small numbers, it's not related to gamma.
-	const float toeLength        =   pow(saturate(PerSceneConstants[3259u].w), 2.2f); // Constant is usually 0.3, but can also be ~0
-	const float toeStrength      =       saturate(PerSceneConstants[3259u].z); // Constant is usually 0.5
-	const float shoulderLength   = clamp(saturate(PerSceneConstants[3260u].y), EPSILON, BTHCNST); // Constant is usually 0.8
-	const float shoulderStrength =            max(PerSceneConstants[3260u].x, 0.f); // Constant is usually 9.9
-	const float shoulderAngle    =       saturate(PerSceneConstants[3260u].z); // Constant is usually 0.3
+	const float toeLength        =   pow(saturate(PerSceneConstants[3255u].w), 2.2f); // Constant is usually 0.3, but can also be ~0
+	const float toeStrength      =       saturate(PerSceneConstants[3255u].z); // Constant is usually 0.5
+	const float shoulderLength   = clamp(saturate(PerSceneConstants[3256u].y), EPSILON, BTHCNST); // Constant is usually 0.8
+	const float shoulderStrength =            max(PerSceneConstants[3256u].x, 0.f); // Constant is usually 9.9
+	const float shoulderAngle    =       saturate(PerSceneConstants[3256u].z); // Constant is usually 0.3
 
 	// Decent range found empirically. It's very extensive.
 	static const float HableShadowModulationMax = 10.f;
@@ -699,7 +699,7 @@ float3 PostProcess(
 	const float  hableSaturation       = HdrCmpDat[hdrCmpDatIndex].HableSaturation;
 	const float  brightnessMultiplier  = HdrCmpDat[hdrCmpDatIndex].BrightnessMultiplier; // Neutral at 1
 	const float  contrastIntensity     = HdrCmpDat[hdrCmpDatIndex].ContrastIntensity; // Neutral at 1
-	const float  contrastMidPoint      = PerSceneConstants[316u].z * MidGrayScale; // Game usually has this around 0.18 (mid gray)
+	const float  contrastMidPoint      = PerSceneConstants[311u].z * MidGrayScale; // Game usually has this around 0.18 (mid gray)
 
 	ColorLuminance = Luminance(Color);
 
@@ -770,7 +770,7 @@ float3 PostProcess_Inverse(
 	const float  hableSaturation       = HdrCmpDat[hdrCmpDatIndex].HableSaturation;
 	const float  brightnessMultiplier  = HdrCmpDat[hdrCmpDatIndex].BrightnessMultiplier; // Neutral at 1
 	const float  contrastIntensity     = HdrCmpDat[hdrCmpDatIndex].ContrastIntensity; // Neutral at 1
-	const float  contrastMidPoint      = PerSceneConstants[316u].z * MidGrayScale;
+	const float  contrastMidPoint      = PerSceneConstants[311u].z * MidGrayScale;
 
 	// We can't invert the color filter, so we will only inverse the post process by the unfiltered amount
 	const float colorFilterInverse = 1.f - colorFilter.a;
@@ -1655,7 +1655,7 @@ void ApplyHDRToneMapperScaling(inout CompositeParams params, inout ToneMapperPar
 		tmParams.inputColor *= 3.5f;
 		tmParams.inputLuminance *= 3.5f;
 	}
-	else if (PerSceneConstants[3259u].w == 0 || PerSceneConstants[3259u].z == 0) // 0-Toe Hable
+	else if (PerSceneConstants[3255u].w == 0 || PerSceneConstants[3255u].z == 0) // 0-Toe Hable
 	{
 		params.outputColor *= 2.8f;
 		tmParams.inputColor *= 2.8f;

--- a/shaders/PostSharpen/PostSharpen_ps.hlsl
+++ b/shaders/PostSharpen/PostSharpen_ps.hlsl
@@ -76,7 +76,7 @@ PSOutput PS(PSInput psInput)
 				inColor = GAMMA_TO_LINEAR(inColor);
 			}
 
-			static const float2 cbConst = PerSceneConstants[161u].zw;
+			static const float2 cbConst = PerSceneConstants[157u].zw;
 
 			float2 _70 = (cbConst * psInput.TEXCOORD.xy * sharpenParams.xy) + 0.5f;
 


### PR DESCRIPTION
Here's my vibe coded attempt to fix compatibility with 1.16.244. Tested with the Steam version on Linux via Proton-cachyos. Summary:

- SFSE submodule bumped to 0.2.21
- Fixed CI, added an upload-artifact step. Useful, as I run Linux and have no other way to build.
- Address library IDs and hook offsets did not need changing. All 34 IDs and 14 hook sites check out against the 1.16.244 database and binary
- The per-scene cbuffer (b0, space3) is the same total size on 1.16.244 — 3313 float4s — but fields moved inside it, so the root signature and cbuffer declaration both still matched and nothing caught it. Fixed.

 Not fixed here: the output stage

 Why the mod still isn't fully correct on 1.16.244. It's a design change, not an offsets update, so it's left out.

 All output encoding — SDR gamma and HDR PQ — lives in Copy_ps.hlsl, and the Copy pass is never dispatched on 1.16.244. Runtime counts, per 60 frames:

 - Copy = 0 always. No Copy-family technique runs at all — not the two handled, nor the other five permutations present — so it isn't a shifted permutation bit. PostSharpen and FilmGrain are also 0, despite PostSharpen being enabled.
- HDRComposite runs a variable number of times: 1×/frame in gameplay, 3× in the tab menu, 0× in the ESC menu — so it can't host a once-per-frame encode.
 - ScaleformComposite is the only steady 1×/frame pass, but it discards where the UI has no influence, so it only touches UI pixels.
- Hook_EndOfFrame fires once per frame and the flag is still set at Hook_PostEndOfFrame, but zero dispatches occur inside the window. The offsets are fine; there's just no pass there.
-  Setting SDR_LINEAR_INTERMEDIARY to 0 makes gameplay in SDR mode look right but isn't a real fix — it breaks the tab menu, where each preview target gets encoded then composited as if still linear.
